### PR TITLE
Fix overlay drag start position in Snapshot Saver

### DIFF
--- a/Website Snapshot Saver 3.6 (Full Features, fflate, ShadowDOM)-3.6.user.js
+++ b/Website Snapshot Saver 3.6 (Full Features, fflate, ShadowDOM)-3.6.user.js
@@ -395,10 +395,16 @@
         iconContainer.addEventListener('mousedown', (e) => {
             e.preventDefault();
             e.stopPropagation();
+
+            const rect = host.getBoundingClientRect();
+            host.style.left = rect.left + 'px';
+            host.style.top = rect.top + 'px';
+            host.style.right = 'auto';
+
             isDragging = true;
             justDragged = false;
-            offsetX = e.clientX - host.offsetLeft;
-            offsetY = e.clientY - host.offsetTop;
+            offsetX = e.clientX - rect.left;
+            offsetY = e.clientY - rect.top;
             document.body.style.userSelect = 'none';
         });
         document.addEventListener('mousemove', (e) => {


### PR DESCRIPTION
## Summary
- ensure overlay drag uses current bounding rect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850e3d031148332bca03dee2a20f8f2