### PR TITLE
Fix drag offset for snapshot saver

### DIFF
--- a/Website Snapshot Saver 3.6 (Full Features, fflate, ShadowDOM)-3.6.user.js
+++ b/Website Snapshot Saver 3.6 (Full Features, fflate, ShadowDOM)-3.6.user.js
@@ -395,6 +395,14 @@
         iconContainer.addEventListener('mousedown', (e) => {
             e.preventDefault();
             e.stopPropagation();
+
+            if (host.style.right) {
+                const rect = host.getBoundingClientRect();
+                host.style.left = rect.left + 'px';
+                host.style.top = rect.top + 'px';
+                host.style.right = 'auto';
+            }
+
             isDragging = true;
             justDragged = false;
             offsetX = e.clientX - host.offsetLeft;


### PR DESCRIPTION
## Summary
- adjust mousedown logic in Website Snapshot Saver 3.6 so initial drag works when element is positioned with `right`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850e3decec48332bf925612a76026e7