### PR TITLE
Fix warnings in Cycloside plugins

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -21,6 +21,7 @@ namespace Cycloside;
 public partial class App : Application
 {
     private const string TrayIconBase64 = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGElEQVR4nGNkaGAgCTCRpnxUw6iGoaQBALsfAKDg6Y6zAAAAAElFTkSuQmCC";
+    private RemoteApiServer? _remoteServer;
 
     public override void Initialize()
     {
@@ -83,8 +84,8 @@ public partial class App : Application
             manager.AddPlugin(new QBasicRetroIDEPlugin());
         }
 
-        var remoteServer = new RemoteApiServer(manager, settings.RemoteApiToken);
-        remoteServer.Start();
+        _remoteServer = new RemoteApiServer(manager, settings.RemoteApiToken);
+        _remoteServer.Start();
         
         WorkspaceProfiles.Apply(settings.ActiveProfile, manager);
 
@@ -220,7 +221,7 @@ public partial class App : Application
                     Command = new RelayCommand(() =>
                     {
                         manager.StopAll();
-                        remoteServer.Stop();
+                        _remoteServer?.Stop();
                         HotkeyManager.UnregisterAll();
                         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime appLifetime)
                         {

--- a/Cycloside/Plugins/BuiltIn/FileWatcherPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/FileWatcherPlugin.cs
@@ -82,7 +82,7 @@ namespace Cycloside.Plugins.BuiltIn
             if (_window == null) return;
 
             // Use the modern, recommended StorageProvider API to open a folder picker.
-            var result = await _window.StorageProvider.OpenFolderPickerAsync(new FilePickerOpenOptions
+            var result = await _window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
             {
                 Title = "Select a folder to watch",
                 AllowMultiple = false

--- a/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
@@ -44,11 +44,11 @@ namespace Cycloside.Plugins.BuiltIn
             var optionsPanel = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Margin = new Avalonia.Thickness(5) };
             var autoScrollCheck = new CheckBox { Content = "Auto-Scroll", IsChecked = true, Margin = new Avalonia.Thickness(5, 0) };
             var wrapLinesCheck = new CheckBox { Content = "Wrap Lines", IsChecked = false, Margin = new Avalonia.Thickness(5, 0) };
-            wrapLinesCheck.IsCheckedChanged += (s, e) =>
+            wrapLinesCheck.IsCheckedChanged += (_, _) =>
             {
                 if (_logBox != null)
                 {
-                    _logBox.TextWrapping = (e.IsChecked ?? false)
+                    _logBox.TextWrapping = wrapLinesCheck.IsChecked == true
                         ? Avalonia.Media.TextWrapping.Wrap
                         : Avalonia.Media.TextWrapping.NoWrap;
                 }
@@ -109,7 +109,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 Title = "Select a log file to view",
                 AllowMultiple = false,
-                FileTypeFilter = new[] { FilePickerFileTypes.TextAll }
+                FileTypeFilter = new[] { FilePickerFileTypes.All }
             });
 
             var path = result.FirstOrDefault()?.TryGetLocalPath();
@@ -251,7 +251,7 @@ namespace Cycloside.Plugins.BuiltIn
                 if (_logBox != null)
                 {
                     var fullMessage = $"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}";
-                    _logBox.AppendText(fullMessage);
+                    _logBox.Text += fullMessage;
                 }
             });
         }

--- a/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
@@ -109,34 +109,46 @@ namespace Cycloside.Plugins.BuiltIn
         #region UI Construction
         private Menu BuildMenu()
         {
-            var fileItems = new[]
-            {
-                new MenuItem { Header = "_New", InputGesture = new KeyGesture(Key.N, KeyModifiers.Control) },
-                new MenuItem { Header = "_Open...", InputGesture = new KeyGesture(Key.O, KeyModifiers.Control) },
-                new MenuItem { Header = "Open _Project..." },
-                new Separator(),
-                new MenuItem { Header = "_Save", InputGesture = new KeyGesture(Key.S, KeyModifiers.Control) },
-                new MenuItem { Header = "Save _As..." },
-                new Separator(),
-                new MenuItem { Header = "E_xit" }
-            };
-            fileItems[0].Click += async (s, e) => await NewFile();
-            fileItems[1].Click += async (s, e) => await OpenFile();
-            fileItems[2].Click += async (s, e) => await OpenProject();
-            fileItems[4].Click += async (s, e) => await SaveFile();
-            fileItems[5].Click += async (s, e) => await SaveFileAs();
-            fileItems[7].Click += (s, e) => _window?.Close();
+            var newItem = new MenuItem { Header = "_New", InputGesture = new KeyGesture(Key.N, KeyModifiers.Control) };
+            var openItem = new MenuItem { Header = "_Open...", InputGesture = new KeyGesture(Key.O, KeyModifiers.Control) };
+            var openProjectItem = new MenuItem { Header = "Open _Project..." };
+            var saveItem = new MenuItem { Header = "_Save", InputGesture = new KeyGesture(Key.S, KeyModifiers.Control) };
+            var saveAsItem = new MenuItem { Header = "Save _As..." };
+            var exitItem = new MenuItem { Header = "E_xit" };
 
-            var editItems = new[]
+            var fileItems = new object[]
             {
-                new MenuItem { Header = "_Undo" }, new MenuItem { Header = "_Redo" }, new Separator(),
-                new MenuItem { Header = "Cu_t" }, new MenuItem { Header = "_Copy" }, new MenuItem { Header = "_Paste" }
+                newItem, openItem, openProjectItem,
+                new Separator(),
+                saveItem, saveAsItem,
+                new Separator(),
+                exitItem
             };
-            editItems[0].Click += (s, e) => _editor?.Undo();
-            editItems[1].Click += (s, e) => _editor?.Redo();
-            editItems[3].Click += (s, e) => _editor?.Cut();
-            editItems[4].Click += (s, e) => _editor?.Copy();
-            editItems[5].Click += (s, e) => _editor?.Paste();
+
+            newItem.Click += async (s, e) => await NewFile();
+            openItem.Click += async (s, e) => await OpenFile();
+            openProjectItem.Click += async (s, e) => await OpenProject();
+            saveItem.Click += async (s, e) => await SaveFile();
+            saveAsItem.Click += async (s, e) => await SaveFileAs();
+            exitItem.Click += (s, e) => _window?.Close();
+
+            var undoItem = new MenuItem { Header = "_Undo" };
+            var redoItem = new MenuItem { Header = "_Redo" };
+            var cutItem = new MenuItem { Header = "Cu_t" };
+            var copyItem = new MenuItem { Header = "_Copy" };
+            var pasteItem = new MenuItem { Header = "_Paste" };
+
+            var editItems = new object[]
+            {
+                undoItem, redoItem, new Separator(),
+                cutItem, copyItem, pasteItem
+            };
+
+            undoItem.Click += (s, e) => _editor?.Undo();
+            redoItem.Click += (s, e) => _editor?.Redo();
+            cutItem.Click += (s, e) => _editor?.Cut();
+            copyItem.Click += (s, e) => _editor?.Copy();
+            pasteItem.Click += (s, e) => _editor?.Paste();
 
             var searchItems = new[] { new MenuItem { Header = "_Find..." }, new MenuItem { Header = "_Replace..." } };
             searchItems[0].Click += async (s, e) => await Find();
@@ -172,13 +184,14 @@ namespace Cycloside.Plugins.BuiltIn
         #endregion
 
         #region File Operations
-        private async Task NewFile()
+        private Task NewFile()
         {
-            if (_editor == null) return;
+            if (_editor == null) return Task.CompletedTask;
             // TODO: Add check for unsaved changes
             _editor.Text = string.Empty;
             _currentFile = null;
             UpdateStatus();
+            return Task.CompletedTask;
         }
 
         private async Task OpenProject()

--- a/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
@@ -111,7 +111,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 Title = "Open Text File",
                 AllowMultiple = false,
-                FileTypeFilter = new[] { FilePickerFileTypes.TextAll }
+                FileTypeFilter = new[] { FilePickerFileTypes.All }
             });
 
             var selectedFile = result.FirstOrDefault();
@@ -152,7 +152,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 Title = "Save Text File As...",
                 SuggestedFileName = Path.GetFileName(_currentFilePath) ?? "Untitled.txt",
-                FileTypeChoices = new[] { FilePickerFileTypes.TextAll }
+                FileTypeChoices = new[] { FilePickerFileTypes.All }
             });
 
             if (result?.TryGetLocalPath() is { } path)


### PR DESCRIPTION
## Summary
- handle line wrapping with `IsCheckedChanged` to avoid obsolete event warning
- return `Task` from `NewFile` to silence analyzer warning

## Testing
- `dotnet --version`
- `dotnet build Cycloside/Cycloside.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685210d8fa98833295a045ca9e4cfb94