### PR TITLE
Clean up PluginManager

### DIFF
--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -250,36 +250,5 @@ namespace Cycloside.Plugins
         public PluginChangeStatus GetStatus(IPlugin plugin) => GetInfo(plugin)?.Status ?? PluginChangeStatus.None;
     }
 
-    /// <summary>
-    /// Custom AssemblyLoadContext to allow for true unloading of plugin DLLs.
-    /// </summary>
-    public class PluginLoadContext : AssemblyLoadContext
-    {
-        private readonly AssemblyDependencyResolver _resolver;
-
-        public PluginLoadContext(string pluginPath) : base(isCollectible: true)
-        {
-            _resolver = new AssemblyDependencyResolver(pluginPath);
-        }
-
-        protected override Assembly? Load(AssemblyName assemblyName)
-        {
-            string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            if (assemblyPath != null)
-            {
-                return LoadFromAssemblyPath(assemblyPath);
-            }
-            return null;
-        }
-
-        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
-        {
-            string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
-            if (libraryPath != null)
-            {
-                return LoadUnmanagedDllFromPath(libraryPath);
-            }
-            return IntPtr.Zero;
-        }
-    }
+    
 }


### PR DESCRIPTION
## Summary
- delete `PluginLoadContext` from `PluginManager`
- keep standalone implementation in `PluginLoadContext.cs`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -warnaserror` *(fails: AVLN1001 WizardWindow.axaml)*

------
https://chatgpt.com/codex/tasks/task_e_68587064e19c8332a555a4384a03b4bf