### PR TITLE
Fix build issues for Cycloside on .NET 8

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -6,7 +6,6 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Cycloside.Plugins;
 using Cycloside.Plugins.BuiltIn;
-using Cycloside.Services;      // Assuming a 'Services' namespace for your managers
 using Cycloside.ViewModels;    // For MainWindowViewModel
 using Cycloside.Views;         // For WizardWindow and MainWindow
 using System;

--- a/Cycloside/MainWindow.axaml
+++ b/Cycloside/MainWindow.axaml
@@ -3,8 +3,10 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:Cycloside.ViewModels"
+        xmlns:p="clr-namespace:Cycloside.Plugins"
         mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="720"
         x:Class="Cycloside.MainWindow"
+        x:Name="RootWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="Cycloside"
         WindowStartupLocation="CenterScreen"
@@ -32,9 +34,9 @@
                 -->
                 <ItemsControl ItemsSource="{Binding AvailablePlugins}">
                     <ItemsControl.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="p:IPlugin">
                             <MenuItem Header="{Binding Name}"
-                                      Command="{Binding DataContext.StartPluginCommand, RelativeSource={RelativeSource AncestorType=Menu}}"
+                                      Command="{Binding DataContext.StartPluginCommand, ElementName=RootWindow}"
                                       CommandParameter="{Binding}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
@@ -26,8 +26,6 @@ namespace Cycloside.Plugins.BuiltIn
             _grid = new DataGrid
             {
                 ItemsSource = _items,
-                CanUserAddRows = false, // We will use a dedicated button for adding
-                CanUserDeleteRows = false, // We will use a dedicated button for deleting
                 AutoGenerateColumns = false, // We will define columns manually for better control
                 Columns =
                 {

--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -150,8 +150,9 @@ namespace Cycloside.Plugins.BuiltIn
             mainLayout.Children.Add(statusBar);
             mainLayout.Children.Add(gamePanel);
 
-            // Assign the layout to the parent window
-            this.Parent.EffectiveVisualChildren.OfType<Window>().FirstOrDefault()!.Content = mainLayout;
+            // Assign the layout to the parent window using the visual root
+            if (VisualRoot is Window parentWindow)
+                parentWindow.Content = mainLayout;
             this.Focusable = true; // Make the game area focusable
 
             // --- Event Handlers ---

--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -1,4 +1,3 @@
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -224,6 +223,10 @@ namespace Cycloside.Plugins
             }
         }
 
+        // StartPlugin is kept for backward compatibility with older code.
+        // It simply calls EnablePlugin, which starts and tracks the plugin.
+        public void StartPlugin(IPlugin plugin) => EnablePlugin(plugin);
+
         public void DisablePlugin(IPlugin plugin)
         {
             var info = GetInfo(plugin);
@@ -250,36 +253,4 @@ namespace Cycloside.Plugins
         public PluginChangeStatus GetStatus(IPlugin plugin) => GetInfo(plugin)?.Status ?? PluginChangeStatus.None;
     }
 
-    /// <summary>
-    /// Custom AssemblyLoadContext to allow for true unloading of plugin DLLs.
-    /// </summary>
-    public class PluginLoadContext : AssemblyLoadContext
-    {
-        private readonly AssemblyDependencyResolver _resolver;
-
-        public PluginLoadContext(string pluginPath) : base(isCollectible: true)
-        {
-            _resolver = new AssemblyDependencyResolver(pluginPath);
-        }
-
-        protected override Assembly? Load(AssemblyName assemblyName)
-        {
-            string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            if (assemblyPath != null)
-            {
-                return LoadFromAssemblyPath(assemblyPath);
-            }
-            return null;
-        }
-
-        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
-        {
-            string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
-            if (libraryPath != null)
-            {
-                return LoadUnmanagedDllFromPath(libraryPath);
-            }
-            return IntPtr.Zero;
-        }
-    }
 }

--- a/Cycloside/ViewModels/MainWindowViewModel.cs
+++ b/Cycloside/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Cycloside.Plugins;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace Cycloside.ViewModels
+{
+    public partial class MainWindowViewModel : ObservableObject
+    {
+        public ObservableCollection<IPlugin> AvailablePlugins { get; }
+
+        public ICommand? ExitCommand { get; set; }
+        public ICommand? StartPluginCommand { get; set; }
+
+        public MainWindowViewModel(IEnumerable<IPlugin> plugins)
+        {
+            AvailablePlugins = new ObservableCollection<IPlugin>(plugins);
+        }
+    }
+}

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
+using Cycloside; // For WorkspaceProfile and other core classes
 using System;
 using System.Collections.ObjectModel;
 using System.IO;

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -10,22 +10,23 @@
         CanResize="False"
         WindowStartupLocation="CenterScreen"
         Title="Cycloside Setup Wizard"
-        <!-- FIX: Set the background to a theme resource to ensure content is always visible. The previous comment format was invalid. -->
         Background="{DynamicResource ApplicationBackgroundBrush}">
+
+    <!-- FIX: Set the background to a theme resource to ensure content is always visible. The previous comment format was invalid. -->
 
     <!-- Replaced the root StackPanel with a DockPanel. -->
     <!-- DockPanel is better for this layout, allowing the buttons to be "docked" -->
     <!-- to the bottom and the TabControl to fill the remaining space correctly. -->
     <DockPanel Margin="15">
 
-        <!-- --- Back/Next Buttons --- -->
+        <!-- Back and Next Buttons -->
         <!-- Buttons are now docked to the bottom for a consistent layout. -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,15,0,0">
             <Button Content="Back" Command="{Binding BackCommand}"/>
             <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True"/>
         </StackPanel>
 
-        <!-- --- Wizard Steps --- -->
+        <!-- Wizard Steps -->
         <!-- The TabControl now fills the main area of the window. -->
         <!-- IsEnabled is bound to prevent clicking tabs directly. -->
         <TabControl SelectedIndex="{Binding CurrentStep}" IsEnabled="False">

--- a/Cycloside/Views/WizardWindow.axaml.cs
+++ b/Cycloside/Views/WizardWindow.axaml.cs
@@ -1,11 +1,7 @@
-// FIX: Added likely using statements for your project's custom manager classes.
-// You may need to adjust these namespaces to match your project structure if they differ.
-using Cycloside.Services; // Assuming a 'Services' or 'Managers' namespace for your managers
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
-
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Cycloside.ViewModels;
+using Cycloside;
 using System; // Required for EventHandler
 
 namespace Cycloside.Views


### PR DESCRIPTION
## Summary
- clean up WizardWindow XAML comments
- add MainWindowViewModel and use ICommand bindings
- remove obsolete references and add `StartPlugin` helper
- fix bindings in MainWindow and update plugins
- ensure `dotnet build Cycloside/Cycloside.csproj` succeeds on .NET 8

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68587068e66c833281ee7a65ed3ef5f7