### PR TITLE
Remove unused Cycloside.Services namespace

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -6,7 +6,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Cycloside.Plugins;
 using Cycloside.Plugins.BuiltIn;
-using Cycloside.Services;      // Assuming a 'Services' namespace for your managers
+// Managers and other helpers live in the base Cycloside namespace
 using Cycloside.ViewModels;    // For MainWindowViewModel
 using Cycloside.Views;         // For WizardWindow and MainWindow
 using System;

--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -1,4 +1,4 @@
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
+using Cycloside; // access SettingsManager and other core services
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
+using Cycloside;          // core models and services
 using System;
 using System.Collections.ObjectModel;
 using System.IO;

--- a/Cycloside/Views/WizardWindow.axaml.cs
+++ b/Cycloside/Views/WizardWindow.axaml.cs
@@ -1,7 +1,6 @@
 // FIX: Added likely using statements for your project's custom manager classes.
 // You may need to adjust these namespaces to match your project structure if they differ.
-using Cycloside.Services; // Assuming a 'Services' or 'Managers' namespace for your managers
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
+using Cycloside;          // core services and models
 
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;


### PR DESCRIPTION
## Summary
- remove references to the old `Cycloside.Services` namespace
- remove stale `Cycloside.Models` usings
- use the base `Cycloside` namespace where needed

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo` *(fails: AVLN1001 invalid XAML in WizardWindow.axaml)*

------
https://chatgpt.com/codex/tasks/task_e_6858706c3158833290317311b021ba4e