### PR TITLE
Add MP3 playlist controls

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -6,7 +6,6 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Cycloside.Plugins;
 using Cycloside.Plugins.BuiltIn;
-using Cycloside.Services;      // Assuming a 'Services' namespace for your managers
 using Cycloside.ViewModels;    // For MainWindowViewModel
 using Cycloside.Views;         // For WizardWindow and MainWindow
 using System;

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -1,41 +1,109 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
 using System;
 using System.IO;
 using System.Linq;
-using NAudio.Wave;
+using System.Threading.Tasks;
 
 namespace Cycloside.Plugins.BuiltIn;
 
 public class MP3PlayerPlugin : IPlugin
 {
-    private IWavePlayer? _output;
-    private AudioFileReader? _reader;
+    private Window? _window;
+    private TextBlock? _trackLabel;
 
     public string Name => "MP3 Player";
-    public string Description => "Plays MP3 files located in the Music folder.";
-    public Version Version => new(1,0,0);
+    public string Description => "Play MP3 files with a simple playlist.";
+    public Version Version => new(1,1,0);
 
     public Widgets.IWidget? Widget => new Widgets.BuiltIn.Mp3Widget();
 
     public void Start()
     {
-        var musicDir = Path.Combine(AppContext.BaseDirectory, "Music");
-        Directory.CreateDirectory(musicDir);
-        var file = Directory.GetFiles(musicDir, "*.mp3").FirstOrDefault();
-        if (file == null)
-            return;
+        var openButton = new Button { Content = "Open..." };
+        openButton.Click += async (_, _) => await OpenFilesAsync();
 
-        _reader = new AudioFileReader(file);
-        _output = new WaveOutEvent();
-        _output.Init(_reader);
-        _output.Play();
+        var prevButton = new Button { Content = "Prev" };
+        prevButton.Click += (_, _) => { Mp3PlaybackService.Previous(); UpdateLabel(); };
+
+        var playButton = new Button { Content = "Play" };
+        playButton.Click += (_, _) => Mp3PlaybackService.Play();
+
+        var pauseButton = new Button { Content = "Pause" };
+        pauseButton.Click += (_, _) => Mp3PlaybackService.Pause();
+
+        var stopButton = new Button { Content = "Stop" };
+        stopButton.Click += (_, _) => Mp3PlaybackService.Stop();
+
+        var nextButton = new Button { Content = "Next" };
+        nextButton.Click += (_, _) => { Mp3PlaybackService.Next(); UpdateLabel(); };
+
+        _trackLabel = new TextBlock
+        {
+            Text = "No file selected",
+            Margin = new Thickness(5),
+            Foreground = Brushes.White
+        };
+
+        var buttonRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
+        buttonRow.Children.Add(openButton);
+        buttonRow.Children.Add(prevButton);
+        buttonRow.Children.Add(playButton);
+        buttonRow.Children.Add(pauseButton);
+        buttonRow.Children.Add(stopButton);
+        buttonRow.Children.Add(nextButton);
+
+        var panel = new StackPanel { Spacing = 4 };
+        panel.Children.Add(buttonRow);
+        panel.Children.Add(_trackLabel);
+
+        _window = new Window
+        {
+            Title = "MP3 Player",
+            Width = 360,
+            Height = 120,
+            Content = panel
+        };
+
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(MP3PlayerPlugin));
+        _window.Show();
+    }
+
+    private async Task OpenFilesAsync()
+    {
+        if (_window == null) return;
+
+        var result = await _window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Select MP3 Files",
+            AllowMultiple = true,
+            FileTypeFilter = new[] { new FilePickerFileType("MP3 Files") { Patterns = new[] { "*.mp3" } } }
+        });
+
+        var files = result.Select(f => f.TryGetLocalPath()).Where(p => p != null).Cast<string>().ToList();
+        if (files.Any())
+        {
+            Mp3PlaybackService.LoadFiles(files);
+            UpdateLabel();
+        }
+    }
+
+    private void UpdateLabel()
+    {
+        if (_trackLabel == null) return;
+        _trackLabel.Text = Mp3PlaybackService.CurrentFile != null
+            ? Path.GetFileName(Mp3PlaybackService.CurrentFile)
+            : "No file selected";
     }
 
     public void Stop()
     {
-        _output?.Stop();
-        _output?.Dispose();
-        _reader?.Dispose();
-        _output = null;
-        _reader = null;
+        _window?.Close();
+        _window = null;
+        _trackLabel = null;
+        Mp3PlaybackService.Stop();
     }
 }
+

--- a/Cycloside/Plugins/BuiltIn/Mp3PlaybackService.cs
+++ b/Cycloside/Plugins/BuiltIn/Mp3PlaybackService.cs
@@ -1,0 +1,76 @@
+using NAudio.Wave;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+internal static class Mp3PlaybackService
+{
+    private static readonly List<string> _playlist = new();
+    private static int _index = -1;
+    private static IWavePlayer? _output;
+    private static AudioFileReader? _reader;
+
+    public static string? CurrentFile =>
+        _index >= 0 && _index < _playlist.Count ? _playlist[_index] : null;
+
+    public static void LoadFiles(IEnumerable<string> files)
+    {
+        Stop();
+        _playlist.Clear();
+        _playlist.AddRange(files.Where(f => File.Exists(f)));
+        _index = _playlist.Count > 0 ? 0 : -1;
+    }
+
+    private static void OpenReader(string file)
+    {
+        _reader = new AudioFileReader(file);
+        _output = new WaveOutEvent();
+        _output.Init(_reader);
+    }
+
+    public static void Play()
+    {
+        if (_playlist.Count == 0)
+            return;
+        if (_output == null || _reader == null)
+            OpenReader(CurrentFile!);
+        _output.Play();
+    }
+
+    public static void Pause() => _output?.Pause();
+
+    public static void Stop()
+    {
+        _output?.Stop();
+        _output?.Dispose();
+        _reader?.Dispose();
+        _output = null;
+        _reader = null;
+    }
+
+    public static void Next()
+    {
+        if (_playlist.Count == 0)
+            return;
+        _index = (_index + 1) % _playlist.Count;
+        Restart();
+    }
+
+    public static void Previous()
+    {
+        if (_playlist.Count == 0)
+            return;
+        _index = (_index - 1 + _playlist.Count) % _playlist.Count;
+        Restart();
+    }
+
+    private static void Restart()
+    {
+        Stop();
+        OpenReader(CurrentFile!);
+        _output?.Play();
+    }
+}
+

--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -1,4 +1,3 @@
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Cycloside/README.md
+++ b/Cycloside/README.md
@@ -18,7 +18,7 @@ Drop any assemblies implementing `Cycloside.Plugins.IPlugin` into the `Plugins` 
 
 Built-in examples:
 - **Date/Time Overlay** – always-on-top clock overlay
-- **MP3 Player** – plays music from the `Music` folder and has a widget
+- **MP3 Player** – choose songs and control playback with a widget
 - **Macro Engine** – record and replay simple keyboard macros
 - **Text Editor** – small editor for notes or Markdown
 - **Wallpaper Changer** – set wallpapers on Windows, Linux or macOS

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -1,7 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
 using System;
 using System.Collections.ObjectModel;
 using System.IO;

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -10,7 +10,6 @@
         CanResize="False"
         WindowStartupLocation="CenterScreen"
         Title="Cycloside Setup Wizard"
-        <!-- FIX: Set the background to a theme resource to ensure content is always visible. The previous comment format was invalid. -->
         Background="{DynamicResource ApplicationBackgroundBrush}">
 
     <!-- Replaced the root StackPanel with a DockPanel. -->
@@ -18,16 +17,13 @@
     <!-- to the bottom and the TabControl to fill the remaining space correctly. -->
     <DockPanel Margin="15">
 
-        <!-- --- Back/Next Buttons --- -->
-        <!-- Buttons are now docked to the bottom for a consistent layout. -->
+        <!-- Back/Next Buttons docked to the bottom for layout -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,15,0,0">
             <Button Content="Back" Command="{Binding BackCommand}"/>
             <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True"/>
         </StackPanel>
 
-        <!-- --- Wizard Steps --- -->
-        <!-- The TabControl now fills the main area of the window. -->
-        <!-- IsEnabled is bound to prevent clicking tabs directly. -->
+        <!-- Wizard Steps - TabControl fills remaining space -->
         <TabControl SelectedIndex="{Binding CurrentStep}" IsEnabled="False">
             <TabItem Header="Welcome">
                 <TextBlock TextWrapping="Wrap" VerticalAlignment="Center" HorizontalAlignment="Center"

--- a/Cycloside/Views/WizardWindow.axaml.cs
+++ b/Cycloside/Views/WizardWindow.axaml.cs
@@ -1,7 +1,4 @@
-// FIX: Added likely using statements for your project's custom manager classes.
-// You may need to adjust these namespaces to match your project structure if they differ.
-using Cycloside.Services; // Assuming a 'Services' or 'Managers' namespace for your managers
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
+
 
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;

--- a/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
+++ b/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
@@ -2,30 +2,48 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
-using NAudio.Wave;
+using Avalonia.Platform.Storage;
+using Avalonia.Controls.ApplicationLifetimes;
 using System;
-using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using Cycloside.Plugins.BuiltIn;
 
 namespace Cycloside.Widgets.BuiltIn;
 
 public class Mp3Widget : IWidget
 {
-    private IWavePlayer? _output;
-    private AudioFileReader? _reader;
 
     public string Name => "MP3 Player";
 
     public Control BuildView()
     {
+        var openButton = new Button { Content = "Open" };
+        openButton.Click += async (_, _) => await PickFilesAsync();
+
+        var prevButton = new Button { Content = "Prev" };
+        prevButton.Click += (_, _) => Mp3PlaybackService.Previous();
+
         var playButton = new Button { Content = "Play" };
-        playButton.Click += (_, _) => Play();
+        playButton.Click += (_, _) => Mp3PlaybackService.Play();
+
+        var pauseButton = new Button { Content = "Pause" };
+        pauseButton.Click += (_, _) => Mp3PlaybackService.Pause();
+
         var stopButton = new Button { Content = "Stop" };
-        stopButton.Click += (_, _) => Stop();
+        stopButton.Click += (_, _) => Mp3PlaybackService.Stop();
+
+        var nextButton = new Button { Content = "Next" };
+        nextButton.Click += (_, _) => Mp3PlaybackService.Next();
 
         var panel = new StackPanel { Orientation = Orientation.Horizontal };
+        panel.Children.Add(openButton);
+        panel.Children.Add(prevButton);
         panel.Children.Add(playButton);
+        panel.Children.Add(pauseButton);
         panel.Children.Add(stopButton);
+        panel.Children.Add(nextButton);
+
         return new Border
         {
             Background = Brushes.Black,
@@ -35,26 +53,20 @@ public class Mp3Widget : IWidget
         };
     }
 
-    private void Play()
+    private async Task PickFilesAsync()
     {
-        var musicDir = Path.Combine(AppContext.BaseDirectory, "Music");
-        Directory.CreateDirectory(musicDir);
-        var file = Directory.GetFiles(musicDir, "*.mp3").FirstOrDefault();
-        if (file == null)
-            return;
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow != null)
+        {
+            var result = await desktop.MainWindow.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Select MP3 Files",
+                AllowMultiple = true,
+                FileTypeFilter = new[] { new FilePickerFileType("MP3 Files") { Patterns = new[] { "*.mp3" } } }
+            });
 
-        _reader = new AudioFileReader(file);
-        _output = new WaveOutEvent();
-        _output.Init(_reader);
-        _output.Play();
-    }
-
-    private void Stop()
-    {
-        _output?.Stop();
-        _output?.Dispose();
-        _reader?.Dispose();
-        _output = null;
-        _reader = null;
+            var files = result.Select(f => f.TryGetLocalPath()).Where(p => p != null).Cast<string>();
+            if (files.Any())
+                Mp3PlaybackService.LoadFiles(files);
+        }
     }
 }

--- a/Cycloside/docs/widget-interface.md
+++ b/Cycloside/docs/widget-interface.md
@@ -34,6 +34,6 @@ This is currently a design document and serves as a guide for future development
 The repository includes a handful of sample widgets to show how the interface works:
 
 - **ClockWidget** – simple digital clock
-- **Mp3Widget** – play and stop the first song in the `Music` folder
+- **Mp3Widget** – pick MP3 files and control playback
 - **WeatherWidget** – fetches temperature data from Open‑Meteo
 


### PR DESCRIPTION
## Summary
- enable picking multiple MP3 files for playback
- add playback control buttons in `MP3PlayerPlugin`
- add similar controls to `Mp3Widget`
- document new widget behaviour

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo` *(fails: MainWindowViewModel not found & other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68587293de708332b79a805f24266942