### PR TITLE
Implement persistent macro plugin

### DIFF
--- a/Cycloside/MacroManager.cs
+++ b/Cycloside/MacroManager.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Cycloside;
+
+public class Macro
+{
+    public string Name { get; set; } = "";
+    public List<string> Keys { get; set; } = new();
+}
+
+public static class MacroManager
+{
+    private static readonly string MacroPath = Path.Combine(AppContext.BaseDirectory, "macros.json");
+    private static List<Macro> _macros = Load();
+
+    public static IReadOnlyList<Macro> Macros => _macros;
+
+    private static List<Macro> Load()
+    {
+        try
+        {
+            if (File.Exists(MacroPath))
+            {
+                var json = File.ReadAllText(MacroPath);
+                var list = JsonSerializer.Deserialize<List<Macro>>(json);
+                if (list != null)
+                    return list;
+            }
+        }
+        catch { }
+        return new List<Macro>();
+    }
+
+    public static void Reload()
+    {
+        _macros = Load();
+    }
+
+    public static void Save()
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(_macros, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(MacroPath, json);
+        }
+        catch { }
+    }
+
+    public static void Add(Macro macro)
+    {
+        _macros.Add(macro);
+        Save();
+    }
+
+    public static void Remove(Macro macro)
+    {
+        _macros.Remove(macro);
+        Save();
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -1,22 +1,178 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using SharpHook;
+using SharpHook.Native;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 
 namespace Cycloside.Plugins.BuiltIn;
 
 public class MacroPlugin : IPlugin
 {
+    private Window? _window;
+    private ListBox? _macroList;
+    private TextBox? _nameBox;
+    private TextBox? _repeatBox;
+    private TextBlock? _status;
+    private IGlobalHook? _hook;
+    private readonly List<string> _recording = new();
+
     public string Name => "Macro Engine";
     public string Description => "Records and plays simple keyboard macros.";
-    public Version Version => new(1,0,0);
+    public Version Version => new(1,1,0);
 
     public Widgets.IWidget? Widget => null;
 
     public void Start()
     {
-        Console.WriteLine("Macro engine started (placeholder)");
+        BuildUi();
+        RefreshList();
+    }
+
+    private void BuildUi()
+    {
+        _macroList = new ListBox { Height = 150 };
+        _nameBox = new TextBox { Watermark = "Macro Name" };
+        _repeatBox = new TextBox { Text = "1", Width = 40 };
+        _status = new TextBlock { Text = "Ready", Margin = new Thickness(5) };
+
+        var recordBtn = new Button { Content = "Record" };
+        recordBtn.Click += (_, __) => StartRecording();
+        var stopBtn = new Button { Content = "Stop" };
+        stopBtn.Click += (_, __) => StopRecording();
+        var playBtn = new Button { Content = "Play" };
+        playBtn.Click += (_, __) => PlaySelected();
+        var saveBtn = new Button { Content = "Save" };
+        saveBtn.Click += (_, __) => { MacroManager.Save(); SetStatus("Saved"); };
+        var loadBtn = new Button { Content = "Reload" };
+        loadBtn.Click += (_, __) => { MacroManager.Reload(); RefreshList(); };
+        var delBtn = new Button { Content = "Delete" };
+        delBtn.Click += (_, __) => DeleteSelected();
+
+        var buttonPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+        buttonPanel.Children.Add(recordBtn);
+        buttonPanel.Children.Add(stopBtn);
+        buttonPanel.Children.Add(playBtn);
+        buttonPanel.Children.Add(saveBtn);
+        buttonPanel.Children.Add(loadBtn);
+        buttonPanel.Children.Add(delBtn);
+
+        var main = new StackPanel { Margin = new Thickness(5) };
+        main.Children.Add(_macroList);
+        main.Children.Add(_nameBox);
+
+        var repeatRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 5 };
+        repeatRow.Children.Add(new TextBlock { Text = "Repeat" });
+        repeatRow.Children.Add(_repeatBox);
+        main.Children.Add(repeatRow);
+
+        main.Children.Add(buttonPanel);
+        main.Children.Add(_status);
+
+        _window = new Window
+        {
+            Title = "Macro Engine",
+            Width = 400,
+            Height = 350,
+            Content = main
+        };
+
+        ThemeManager.ApplyFromSettings(_window, "Plugins");
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(MacroPlugin));
+        _window.Show();
+    }
+
+    private void StartRecording()
+    {
+        if (_hook != null) return;
+        _recording.Clear();
+        _hook = new TaskPoolGlobalHook();
+        _hook.KeyPressed += OnKeyPressed;
+        _hook.RunAsync();
+        SetStatus("Recording...");
+    }
+
+    private void StopRecording()
+    {
+        if (_hook == null) return;
+        _hook.Dispose();
+        _hook = null;
+        var name = _nameBox?.Text;
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            MacroManager.Add(new Macro { Name = name!, Keys = _recording.ToList() });
+            RefreshList();
+            SetStatus($"Recorded {name}");
+        }
+        else
+        {
+            SetStatus("No name specified");
+        }
+    }
+
+    private void OnKeyPressed(object? sender, KeyboardHookEventArgs e)
+    {
+        _recording.Add(e.Data.KeyCode.ToString());
+    }
+
+    private void PlaySelected()
+    {
+        if (_macroList?.SelectedIndex >= 0 && _macroList.SelectedIndex < MacroManager.Macros.Count)
+        {
+            var macro = MacroManager.Macros[_macroList.SelectedIndex];
+            if (!int.TryParse(_repeatBox?.Text, out var repeat) || repeat < 1) repeat = 1;
+            for (int r = 0; r < repeat; r++)
+            {
+                foreach (var key in macro.Keys)
+                {
+                    try
+                    {
+                        if (OperatingSystem.IsWindows())
+                            System.Windows.Forms.SendKeys.SendWait(key);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Macro playback error: {ex.Message}");
+                    }
+                }
+            }
+            SetStatus($"Played '{macro.Name}' {repeat}x");
+        }
+    }
+
+    private void DeleteSelected()
+    {
+        if (_macroList?.SelectedIndex >= 0 && _macroList.SelectedIndex < MacroManager.Macros.Count)
+        {
+            var macro = MacroManager.Macros[_macroList.SelectedIndex];
+            MacroManager.Remove(macro);
+            RefreshList();
+            SetStatus($"Deleted {macro.Name}");
+        }
+    }
+
+    private void RefreshList()
+    {
+        if (_macroList != null)
+        {
+            _macroList.Items = MacroManager.Macros.Select(m => m.Name).ToList();
+        }
+    }
+
+    private void SetStatus(string msg)
+    {
+        Dispatcher.UIThread.InvokeAsync(() => { if (_status != null) _status.Text = msg; });
     }
 
     public void Stop()
     {
-        Console.WriteLine("Macro engine stopped");
+        _hook?.Dispose();
+        _hook = null;
+        _window?.Close();
+        _window = null;
     }
 }

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -10,22 +10,22 @@
         CanResize="False"
         WindowStartupLocation="CenterScreen"
         Title="Cycloside Setup Wizard"
-        <!-- FIX: Set the background to a theme resource to ensure content is always visible. The previous comment format was invalid. -->
         Background="{DynamicResource ApplicationBackgroundBrush}">
+    <!-- Set the background to a theme resource to ensure content is always visible. -->
 
     <!-- Replaced the root StackPanel with a DockPanel. -->
     <!-- DockPanel is better for this layout, allowing the buttons to be "docked" -->
     <!-- to the bottom and the TabControl to fill the remaining space correctly. -->
     <DockPanel Margin="15">
 
-        <!-- --- Back/Next Buttons --- -->
+        <!-- Back/Next Buttons -->
         <!-- Buttons are now docked to the bottom for a consistent layout. -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,15,0,0">
             <Button Content="Back" Command="{Binding BackCommand}"/>
             <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True"/>
         </StackPanel>
 
-        <!-- --- Wizard Steps --- -->
+        <!-- Wizard Steps -->
         <!-- The TabControl now fills the main area of the window. -->
         <!-- IsEnabled is bound to prevent clicking tabs directly. -->
         <TabControl SelectedIndex="{Binding CurrentStep}" IsEnabled="False">

--- a/README-dev.md
+++ b/README-dev.md
@@ -33,7 +33,7 @@ planned features for the Cycloside project.
 | `JezzballPlugin` | Simple recreation of the classic game. |
 | `LogViewerPlugin` | Tails a log file and filters lines on the fly. |
 | `MP3PlayerPlugin` | Basic audio player built on NAudio. |
-| `MacroPlugin` | Records simple text macros and replays them. |
+| `MacroPlugin` | Records keyboard macros, saves them to disk and supports multi-playback. |
 | `ProcessMonitorPlugin` | Lists running processes with CPU and memory usage. |
 | `QBasicRetroIDEPlugin` | Minimal IDE for creating QBasic-style programs. |
 | `TaskSchedulerPlugin` | Schedules tasks with cron-style expressions. |


### PR DESCRIPTION
## Summary
- persist macros to disk using new `MacroManager`
- expand `MacroPlugin` with UI to record, save, load, delete and repeat macros
- fix invalid comments in `WizardWindow.axaml`
- document improved MacroPlugin in developer notes

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo` *(fails: Services namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858729571348332b4f35f467ec4b0e1