### PR TITLE
Update App.axaml plugin command

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -91,7 +91,7 @@ namespace Cycloside
             // Connect ViewModel commands to application logic
             viewModel.ExitCommand = new RelayCommand(() => Shutdown(manager));
             viewModel.StartPluginCommand = new RelayCommand(plugin => {
-                if(plugin is IPlugin p) manager.StartPlugin(p);
+                if (plugin is IPlugin p) manager.EnablePlugin(p);
             });
 
             // --- Server & Hotkey Setup ---


### PR DESCRIPTION
## Summary
- use `EnablePlugin` rather than deprecated `StartPlugin` when invoking plugin start

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal` *(fails: Avalonia error AVLN1001 in WizardWindow.axaml)*

------
https://chatgpt.com/codex/tasks/task_e_685872a2f8288332b12ac6b44f700cf0