### PR TITLE
Clean unused namespaces

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -6,7 +6,6 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Cycloside.Plugins;
 using Cycloside.Plugins.BuiltIn;
-using Cycloside.Services;      // Assuming a 'Services' namespace for your managers
 using Cycloside.ViewModels;    // For MainWindowViewModel
 using Cycloside.Views;         // For WizardWindow and MainWindow
 using System;

--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -1,4 +1,3 @@
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -1,7 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
-using Cycloside.Services; // Assuming a 'Services' namespace for your managers
 using System;
 using System.Collections.ObjectModel;
 using System.IO;

--- a/Cycloside/Views/WizardWindow.axaml.cs
+++ b/Cycloside/Views/WizardWindow.axaml.cs
@@ -1,7 +1,3 @@
-// FIX: Added likely using statements for your project's custom manager classes.
-// You may need to adjust these namespaces to match your project structure if they differ.
-using Cycloside.Services; // Assuming a 'Services' or 'Managers' namespace for your managers
-using Cycloside.Models;   // Assuming a 'Models' namespace for WorkspaceProfile
 
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;


### PR DESCRIPTION
## Summary
- drop `Cycloside.Services` and `Cycloside.Models` usings
- remove intro comments referencing those namespaces

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal` *(fails: AVLN1001 invalid XAML)*

------
https://chatgpt.com/codex/tasks/task_e_685872bbd0608332bdc384d97eec4d68