### PR TITLE
Fix SDK plugin namespace

### DIFF
--- a/Cycloside/SDK/Examples/ExamplePlugin.cs
+++ b/Cycloside/SDK/Examples/ExamplePlugin.cs
@@ -1,5 +1,5 @@
 using System;
-using SiloCide.SDK;
+using Cycloside.Plugins;
 
 public class ExamplePlugin : IPlugin
 {

--- a/Cycloside/SDK/IPlugin.cs
+++ b/Cycloside/SDK/IPlugin.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SiloCide.SDK;
+namespace Cycloside.Plugins;
 
 public interface IPlugin
 {

--- a/Cycloside/SDK/IPluginExtended.cs
+++ b/Cycloside/SDK/IPluginExtended.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SiloCide.SDK;
+namespace Cycloside.Plugins;
 
 public interface IPluginExtended : IPlugin
 {


### PR DESCRIPTION
## Summary
- update plugin interfaces to use `Cycloside.Plugins`
- adjust ExamplePlugin to new namespace

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: AVLN1001 invalid XAML)*

------
https://chatgpt.com/codex/tasks/task_e_6858d14a9a288332a117835206070dbc