### PR TITLE
Add city option for Weather widget

### DIFF
--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -30,6 +30,7 @@ namespace Cycloside.Plugins.BuiltIn
         public string Description => "Play MP3 files with a simple playlist.";
         public Version Version => new(1, 2, 0); // Incremented for major refactor
         public Widgets.IWidget? Widget => new Widgets.BuiltIn.Mp3Widget(this);
+        public bool ForceDefaultTheme => false;
 
         // --- Observable Properties for UI Binding ---
         [ObservableProperty]
@@ -49,7 +50,7 @@ namespace Cycloside.Plugins.BuiltIn
             // No action needed on start, as this plugin is controlled by its widget.
         }
 
-        public void Stop()
+        void IPlugin.Stop()
         {
             // This is the definitive cleanup method called by the host.
             CleanupPlayback();

--- a/Cycloside/SettingsManager.cs
+++ b/Cycloside/SettingsManager.cs
@@ -26,6 +26,7 @@ public class AppSettings
     public Dictionary<string, ThemeSnapshot> SavedThemes { get; set; } = new();
     public double WeatherLatitude { get; set; } = 35;
     public double WeatherLongitude { get; set; } = 139;
+    public string WeatherCity { get; set; } = "";
     public string ActiveProfile { get; set; } = "default";
     public string RemoteApiToken { get; set; } = "secret";
     public bool FirstRun { get; set; } = true;

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -11,15 +11,15 @@
     <DockPanel Margin="15">
 
 <StackPanel DockPanel.Dock="Bottom"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,15,0,0">
-            <Button Content="Back" Command="{Binding BackCommand}" />
-            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
-        </StackPanel>
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,15,0,0">
+            <Button Content="Back" Command="{Binding BackCommand}" />
+            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
+        </StackPanel>
 
-                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
+                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
             <TabItem Header="Welcome">
                 <TextBlock TextWrapping="Wrap"
                            VerticalAlignment="Center"

--- a/Cycloside/Widgets/BuiltIn/WeatherSettingsWindow.cs
+++ b/Cycloside/Widgets/BuiltIn/WeatherSettingsWindow.cs
@@ -12,6 +12,7 @@ public class WeatherSettingsWindow : Window
 {
     private readonly TextBox _latBox;
     private readonly TextBox _lonBox;
+    private readonly TextBox _cityBox;
     private readonly Action _onSaved;
 
     public WeatherSettingsWindow(Action onSaved)
@@ -23,6 +24,9 @@ public class WeatherSettingsWindow : Window
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
 
         var panel = new StackPanel { Margin = new Thickness(10), Spacing = 5 };
+        panel.Children.Add(new TextBlock { Text = "City (optional):" });
+        _cityBox = new TextBox { Text = SettingsManager.Settings.WeatherCity };
+        panel.Children.Add(_cityBox);
         panel.Children.Add(new TextBlock { Text = "Latitude:" });
         _latBox = new TextBox { Text = SettingsManager.Settings.WeatherLatitude.ToString() };
         panel.Children.Add(_latBox);
@@ -46,6 +50,7 @@ public class WeatherSettingsWindow : Window
             SettingsManager.Settings.WeatherLatitude = lat;
         if (double.TryParse(_lonBox.Text, out var lon))
             SettingsManager.Settings.WeatherLongitude = lon;
+        SettingsManager.Settings.WeatherCity = _cityBox.Text ?? string.Empty;
         SettingsManager.Save();
         _onSaved?.Invoke();
         Close();

--- a/Cycloside/Widgets/BuiltIn/WeatherWidget.cs
+++ b/Cycloside/Widgets/BuiltIn/WeatherWidget.cs
@@ -40,6 +40,20 @@ public class WeatherWidget : IWidget
             using var client = new HttpClient();
             var lat = SettingsManager.Settings.WeatherLatitude;
             var lon = SettingsManager.Settings.WeatherLongitude;
+            var city = SettingsManager.Settings.WeatherCity;
+            if (!string.IsNullOrWhiteSpace(city))
+            {
+                var geoUrl = $"https://geocoding-api.open-meteo.com/v1/search?name={Uri.EscapeDataString(city)}&count=1";
+                var geoJson = await client.GetStringAsync(geoUrl);
+                using var geoDoc = JsonDocument.Parse(geoJson);
+                if (geoDoc.RootElement.TryGetProperty("results", out var res) && res.GetArrayLength() > 0)
+                {
+                    var first = res[0];
+                    lat = first.GetProperty("latitude").GetDouble();
+                    lon = first.GetProperty("longitude").GetDouble();
+                }
+            }
+
             var url = $"https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current_weather=true";
             var json = await client.GetStringAsync(url);
             using var doc = JsonDocument.Parse(json);

--- a/Cycloside/docs/widget-interface.md
+++ b/Cycloside/docs/widget-interface.md
@@ -37,6 +37,6 @@ The repository includes a handful of sample widgets to show how the interface wo
 - **Mp3Widget** – pick MP3 files and control playback
 - **WeatherWidget** – fetches temperature data from Open‑Meteo
 
-Double‑click the Weather widget to set your latitude and longitude. The values
+Double‑click the Weather widget to set your city or latitude and longitude. The values
 are stored in `settings.json` and used when requesting weather data.
 


### PR DESCRIPTION
## Summary
- allow user to set `WeatherCity` alongside latitude/longitude
- update WeatherSettingsWindow to edit city
- fetch coordinates from a city name in WeatherWidget
- clarify docs for configuring the Weather widget
- minor cleanup of MP3PlayerPlugin and WizardWindow

## Testing
- `dotnet build Cycloside/Cycloside.csproj -clp:ErrorsOnly` *(fails: ThemeManager missing in other plugins)*

------
https://chatgpt.com/codex/tasks/task_e_685ca42765c0833287f5339a147dff20