### PR TITLE
Move plugin UI layout to XAML

### DIFF
--- a/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
@@ -22,7 +22,8 @@ public class ClipboardManagerPlugin : IPlugin
 
     public void Start()
     {
-        _list = new ListBox();
+        _window = new ClipboardManagerWindow();
+        _list = _window.FindControl<ListBox>("HistoryList");
         _list.DoubleTapped += async (_, __) =>
         {
             if (_list.SelectedItem is string text && _window != null)
@@ -31,14 +32,6 @@ public class ClipboardManagerPlugin : IPlugin
                 if (cb != null)
                     await cb.SetTextAsync(text);
             }
-        };
-
-        _window = new Window
-        {
-            Title = "Clipboard History",
-            Width = 300,
-            Height = 400,
-            Content = _list
         };
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(ClipboardManagerPlugin));
         _window.Show();

--- a/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
@@ -21,20 +21,10 @@ public class DateTimeOverlayPlugin : IPlugin
 
     public void Start()
     {
-        _window = new Window
-        {
-            Width = 200,
-            Height = 40,
-            SystemDecorations = SystemDecorations.None,
-            CanResize = false,
-            Topmost = true,
-            Background = Brushes.Black,
-            Opacity = 0.7,
-        };
+        _window = new DateTimeOverlayWindow();
+        var text = _window.FindControl<TextBlock>("TimeText");
         CursorManager.ApplyFromSettings(_window, "Plugins");
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DateTimeOverlayPlugin));
-        var text = new TextBlock { Foreground = Brushes.White, HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
-        _window.Content = text;
         _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _timer.Tick += (_, _) =>
         {

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -30,12 +30,13 @@ namespace Cycloside.Plugins.BuiltIn
         public string Description => "Play MP3 files with a simple playlist.";
         public Version Version => new(1, 2, 0); // Incremented for major refactor
         public Widgets.IWidget? Widget => new Widgets.BuiltIn.Mp3Widget(this);
+        public bool ForceDefaultTheme => false;
 
         // --- Observable Properties for UI Binding ---
         [ObservableProperty]
         [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
         [NotifyCanExecuteChangedFor(nameof(PauseCommand))]
-        [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+        [NotifyCanExecuteChangedFor(nameof(StopPlaybackCommand))]
         [NotifyCanExecuteChangedFor(nameof(NextCommand))]
         [NotifyCanExecuteChangedFor(nameof(PreviousCommand))]
         private string? _currentTrackName;
@@ -107,7 +108,7 @@ namespace Cycloside.Plugins.BuiltIn
         private void Pause() => _wavePlayer?.Pause();
 
         [RelayCommand(CanExecute = nameof(CanStop))]
-        private void Stop() => CleanupPlayback();
+        private void StopPlayback() => CleanupPlayback();
 
         [RelayCommand(CanExecute = nameof(HasNext))]
         private void Next() => SkipToTrack(_currentIndex + 1);
@@ -220,7 +221,7 @@ namespace Cycloside.Plugins.BuiltIn
             // When IsPlaying changes, we need to re-evaluate the CanExecute status of our commands.
             PlayCommand.NotifyCanExecuteChanged();
             PauseCommand.NotifyCanExecuteChanged();
-            StopCommand.NotifyCanExecuteChanged();
+            StopPlaybackCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
@@ -1,0 +1,7 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Cycloside.Plugins.BuiltIn.ClipboardManagerWindow"
+        Title="Clipboard History"
+        Width="300" Height="400">
+    <ListBox x:Name="HistoryList"/>
+</Window>

--- a/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public partial class ClipboardManagerWindow : Window
+{
+    public ClipboardManagerWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/Views/DateTimeOverlayWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/DateTimeOverlayWindow.axaml
@@ -1,0 +1,11 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Cycloside.Plugins.BuiltIn.DateTimeOverlayWindow"
+        Width="200" Height="40"
+        SystemDecorations="None" CanResize="False" Topmost="True"
+        Background="Black" Opacity="0.7">
+    <TextBlock x:Name="TimeText"
+               Foreground="White"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"/>
+</Window>

--- a/Cycloside/Plugins/BuiltIn/Views/DateTimeOverlayWindow.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/DateTimeOverlayWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public partial class DateTimeOverlayWindow : Window
+{
+    public DateTimeOverlayWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -11,15 +11,15 @@
     <DockPanel Margin="15">
 
 <StackPanel DockPanel.Dock="Bottom"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,15,0,0">
-            <Button Content="Back" Command="{Binding BackCommand}" />
-            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
-        </StackPanel>
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,15,0,0">
+            <Button Content="Back" Command="{Binding BackCommand}" />
+            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
+        </StackPanel>
 
-                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
+                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
             <TabItem Header="Welcome">
                 <TextBlock TextWrapping="Wrap"
                            VerticalAlignment="Center"

--- a/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
+++ b/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
@@ -49,7 +49,7 @@ namespace Cycloside.Widgets.BuiltIn
             var prevButton = new Button { Content = "◀", Command = _plugin.PreviousCommand };
             var playButton = new Button { Content = "▶", Command = _plugin.PlayCommand };
             var pauseButton = new Button { Content = "❚❚", Command = _plugin.PauseCommand };
-            var stopButton = new Button { Content = "■", Command = _plugin.StopCommand };
+            var stopButton = new Button { Content = "■", Command = _plugin.StopPlaybackCommand };
             var nextButton = new Button { Content = "▶|", Command = _plugin.NextCommand };
 
             // --- Assemble Layout ---


### PR DESCRIPTION
## Summary
- convert clipboard and date/time plugins to XAML based windows
- load XAML in plugin `Start()` methods
- fix wizard XAML whitespace
- update MP3 player naming to avoid conflicts

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo` *(fails: `ThemeManager` missing and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ca42a78fc8332949492119b5f69f2