### PR TITLE
Mark Macro plugin Windows-only

### DIFF
--- a/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
@@ -37,7 +37,6 @@ namespace Cycloside.Plugins.BuiltIn
 
             // Apply theming and effects (assuming these are valid managers in your project)
             
-            ThemeManager.ApplyFromSettings(_window, "Plugins");
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DiskUsagePlugin));
 
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -30,12 +30,13 @@ namespace Cycloside.Plugins.BuiltIn
         public string Description => "Play MP3 files with a simple playlist.";
         public Version Version => new(1, 2, 0); // Incremented for major refactor
         public Widgets.IWidget? Widget => new Widgets.BuiltIn.Mp3Widget(this);
+        public bool ForceDefaultTheme => false;
 
         // --- Observable Properties for UI Binding ---
         [ObservableProperty]
         [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
         [NotifyCanExecuteChangedFor(nameof(PauseCommand))]
-        [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+        [NotifyCanExecuteChangedFor(nameof(StopPlaybackCommand))]
         [NotifyCanExecuteChangedFor(nameof(NextCommand))]
         [NotifyCanExecuteChangedFor(nameof(PreviousCommand))]
         private string? _currentTrackName;
@@ -107,7 +108,7 @@ namespace Cycloside.Plugins.BuiltIn
         private void Pause() => _wavePlayer?.Pause();
 
         [RelayCommand(CanExecute = nameof(CanStop))]
-        private void Stop() => CleanupPlayback();
+        private void StopPlayback() => CleanupPlayback();
 
         [RelayCommand(CanExecute = nameof(HasNext))]
         private void Next() => SkipToTrack(_currentIndex + 1);
@@ -220,7 +221,7 @@ namespace Cycloside.Plugins.BuiltIn
             // When IsPlaying changes, we need to re-evaluate the CanExecute status of our commands.
             PlayCommand.NotifyCanExecuteChanged();
             PauseCommand.NotifyCanExecuteChanged();
-            StopCommand.NotifyCanExecuteChanged();
+            StopPlaybackCommand.NotifyCanExecuteChanged();
         }
     }
 }

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Threading;
+using System.Runtime.Versioning;
 using SharpHook;
 using SharpHook.Native;
 using System;
@@ -12,6 +13,7 @@ using Cycloside.Services;
 
 namespace Cycloside.Plugins.BuiltIn;
 
+[SupportedOSPlatform("windows")]
 public class MacroPlugin : IPlugin
 {
     private Window? _window;
@@ -25,7 +27,7 @@ public class MacroPlugin : IPlugin
     private readonly List<string> _recording = new();
 
     public string Name => "Macro Engine";
-    public string Description => "Records keyboard macros (playback Windows-only).";
+    public string Description => "Windows-only macro recorder and player.";
     public Version Version => new(1,1,0);
 
     public Widgets.IWidget? Widget => null;
@@ -33,13 +35,14 @@ public class MacroPlugin : IPlugin
 
     public void Start()
     {
-        BuildUi();
-        RefreshList();
         if (!_isWindows)
         {
-            _playButton!.IsEnabled = false;
-            SetStatus("Macro playback is only available on Windows.");
+            Logger.Log("Macro Engine plugin is Windows-only and has been disabled.");
+            return;
         }
+
+        BuildUi();
+        RefreshList();
     }
 
     private void BuildUi()
@@ -145,7 +148,6 @@ public class MacroPlugin : IPlugin
                 {
                     try
                     {
-                        System.Windows.Forms.SendKeys.SendWait(key);
                         // Key playback is only supported on Windows via SendKeys.
                         if (OperatingSystem.IsWindows())
                         {

--- a/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
@@ -57,8 +57,7 @@ namespace Cycloside.Plugins.BuiltIn
                 AcceptsTab = true,
                 FontFamily = new FontFamily("monospace"),
                 TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(5, 0, 5, 5),
-                [!TextBox.TextProperty] = Avalonia.Data.BindingMode.OneWayToSource
+                Margin = new Thickness(5, 0, 5, 5)
             };
             ScrollViewer.SetHorizontalScrollBarVisibility(_editorBox, ScrollBarVisibility.Auto);
             ScrollViewer.SetVerticalScrollBarVisibility(_editorBox, ScrollBarVisibility.Auto);

--- a/Cycloside/Plugins/BuiltIn/WallpaperPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WallpaperPlugin.cs
@@ -44,7 +44,6 @@ namespace Cycloside.Plugins.BuiltIn
                 }
             };
             PluginBus.Subscribe("wallpaper:set", _wallpaperHandler);
-            ThemeManager.ApplyFromSettings(_window, "Plugins");
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(WallpaperPlugin));
             _window.Show();
         }

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -11,15 +11,15 @@
     <DockPanel Margin="15">
 
 <StackPanel DockPanel.Dock="Bottom"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,15,0,0">
-            <Button Content="Back" Command="{Binding BackCommand}" />
-            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
-        </StackPanel>
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,15,0,0">
+            <Button Content="Back" Command="{Binding BackCommand}" />
+            <Button Content="Next" Command="{Binding NextCommand}" IsDefault="True" />
+        </StackPanel>
 
-                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
+                <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
             <TabItem Header="Welcome">
                 <TextBlock TextWrapping="Wrap"
                            VerticalAlignment="Center"

--- a/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
+++ b/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
@@ -49,7 +49,7 @@ namespace Cycloside.Widgets.BuiltIn
             var prevButton = new Button { Content = "◀", Command = _plugin.PreviousCommand };
             var playButton = new Button { Content = "▶", Command = _plugin.PlayCommand };
             var pauseButton = new Button { Content = "❚❚", Command = _plugin.PauseCommand };
-            var stopButton = new Button { Content = "■", Command = _plugin.StopCommand };
+            var stopButton = new Button { Content = "■", Command = _plugin.StopPlaybackCommand };
             var nextButton = new Button { Content = "▶|", Command = _plugin.NextCommand };
 
             // --- Assemble Layout ---


### PR DESCRIPTION
## Summary
- mark Macro plugin as Windows-only and skip startup on other platforms
- clean invalid characters from WizardWindow.axaml
- fix MP3 player command names and implement required interface members
- remove outdated ThemeManager calls and bad binding in TextEditor
- verify project builds

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685ca4468c148332ac37e20132f2d95e