### PR TITLE
Enable Windows Forms

### DIFF
--- a/Cycloside/Cycloside.csproj
+++ b/Cycloside/Cycloside.csproj
@@ -7,6 +7,7 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable Windows Forms in Cycloside

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: NETSDK1136)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc25e7dc83328f2d6b842183e238