### PR TITLE
Remove IsLocked condition for wizard window

### DIFF
--- a/Cycloside/Views/WizardWindow.axaml.cs
+++ b/Cycloside/Views/WizardWindow.axaml.cs
@@ -39,8 +39,8 @@ namespace Cycloside.Views
             // We only want to drag when the left mouse button is pressed.
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
-                // Check if the DataContext is our ViewModel and if it's not locked.
-                if (DataContext is WizardViewModel vm && !vm.IsLocked)
+                // Ensure the DataContext is our ViewModel before dragging.
+                if (DataContext is WizardViewModel)
                 {
                     // This command tells the OS to start a drag operation.
                     BeginMoveDrag(e);


### PR DESCRIPTION
## Summary
- remove IsLocked check from `Window_PointerPressed` so WizardWindow is always draggable

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal` *(fails: MP3PlayerPlugin OpenFilesCommand missing and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc2ccb2083329908580525d9b42e