### PR TITLE
Update Cycloside target frameworks

### DIFF
--- a/Cycloside/Cycloside.csproj
+++ b/Cycloside/Cycloside.csproj
@@ -2,11 +2,14 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows'">
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- allow building on both net8.0 and net8.0-windows
- only enable Windows Forms on the Windows target

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: EnableWindowsTargeting property)*

------
https://chatgpt.com/codex/tasks/task_e_685e00dbbae0833297273e27b46f3efb