### PR TITLE
Fix macro plugin OS check

### DIFF
--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -115,7 +115,6 @@ public class MacroPlugin : IPlugin
                     try
                     {
                         // Key playback is only supported on Windows via SendKeys.
-                        if (OperatingSystem.IsWindows())
                         if (_isWindows)
                         {
                             // Windows uses SendKeys for playback.


### PR DESCRIPTION
## Summary
- trim duplicate OS check around SendKeys

## Testing
- `dotnet build Cycloside/Cycloside.csproj -consoleloggerparameters:Summary` *(fails: The target platform must be set to Windows)*

------
https://chatgpt.com/codex/tasks/task_e_685e00dd197c8332a85c87c16b017272