### PR TITLE
Fix build issues in Cycloside

### DIFF
--- a/Cycloside/Cycloside.csproj
+++ b/Cycloside/Cycloside.csproj
@@ -12,6 +12,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows'">
     <UseWindowsForms>true</UseWindowsForms>
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +24,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.1" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.1" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.0.11" />
+    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.3.1" />
+    <PackageReference Include="Avalonia.Xaml.Interactions" Version="11.3.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="MoonSharp" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />

--- a/Cycloside/Plugins/BuiltIn/DateTimeOverlayWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/DateTimeOverlayWindow.axaml
@@ -29,7 +29,7 @@
   <Window.ContextMenu>
     <ContextMenu>
       <MenuItem Header="Cycle Format" Command="{Binding CycleFormatCommand}"/>
-      <MenuItem Header="Lock Position" IsCheckable="True" IsChecked="{Binding IsLocked, Mode=TwoWay}"/>
+      <MenuItem Header="Lock Position" ToggleType="CheckBox" IsChecked="{Binding IsLocked, Mode=TwoWay}"/>
       <Separator/>
       <MenuItem Header="Close" Command="{Binding CloseCommand}"/>
     </ContextMenu>

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -9,6 +9,9 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Cycloside.Services;
+#if WINDOWS
+using System.Windows.Forms;
+#endif
 
 // Playback uses SendKeys on Windows. On Linux and macOS, SharpHook's
 // EventSimulator is used to emulate key presses. These platforms may
@@ -117,8 +120,10 @@ public class MacroPlugin : IPlugin
                         // Key playback is only supported on Windows via SendKeys.
                         if (_isWindows)
                         {
+#if WINDOWS
                             // Windows uses SendKeys for playback.
-                            System.Windows.Forms.SendKeys.SendWait(key);
+                            SendKeys.SendWait(key);
+#endif
                         }
                         else if (Enum.TryParse<KeyCode>(key, out var code))
                         {

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -24,6 +24,17 @@ namespace Cycloside.ViewModels
         [ObservableProperty]
         private int currentStep;
 
+        partial void OnCurrentStepChanged(int value)
+        {
+            OnPropertyChanged(nameof(CanGoBack));
+            OnPropertyChanged(nameof(NextButtonText));
+            OnPropertyChanged(nameof(ProgressText));
+        }
+        
+        public string ProgressText => $"Step {CurrentStep + 1} of 5";
+        public bool CanGoBack => CurrentStep > 0;
+        public string NextButtonText => CurrentStep < 4 ? "Next" : "Finish";
+
         [ObservableProperty]
         private string selectedTheme = string.Empty;
 

--- a/Cycloside/Views/WizardWindow.axaml
+++ b/Cycloside/Views/WizardWindow.axaml
@@ -29,9 +29,6 @@
     </DockPanel>
 
     <TabControl SelectedIndex="{Binding CurrentStep, Mode=OneWay}" IsEnabled="False">
-      <TabControl.PageTransition>
-        <CrossFade Duration="0.25"/>
-      </TabControl.PageTransition>
 
       <TabItem Header="Welcome">
         <TextBlock TextWrapping="Wrap"


### PR DESCRIPTION
## Summary
- define WINDOWS constant in csproj and upgrade Avalonia packages
- add missing Avalonia.Xaml.Interactions reference
- make MacroPlugin's SendKeys usage windows-only
- fix menu item binding in DateTime overlay window
- implement missing wizard view model properties and remove obsolete transition

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build Cycloside/Cycloside.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e08e069548332a7d78bbb0667fbde