### PR TITLE
Fix build and document SDK requirements

### DIFF
--- a/Cycloside/MainWindow.axaml
+++ b/Cycloside/MainWindow.axaml
@@ -52,7 +52,7 @@
         -->
         <Canvas Name="DesktopCanvas">
             <Canvas.Background>
-                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" Radius="0.7">
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="70%" RadiusY="70%">
                     <GradientStop Color="{DynamicResource ThemeAccentColor4}" Offset="0" />
                     <GradientStop Color="{DynamicResource ThemeBackgroundColor}" Offset="1" />
                 </RadialGradientBrush>

--- a/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
@@ -87,10 +87,10 @@ namespace Cycloside.Plugins.BuiltIn
                 _logBox.TextWrapping = Avalonia.Media.TextWrapping.NoWrap;
                 _logBox.FontFamily = "Cascadia Code,Consolas,Menlo,monospace";
                 _logBox.Margin = new Avalonia.Thickness(5);
+                ScrollViewer.SetHorizontalScrollBarVisibility(_logBox, ScrollBarVisibility.Auto);
+                ScrollViewer.SetVerticalScrollBarVisibility(_logBox, ScrollBarVisibility.Auto);
+                _logBox.TextChanged += OnLogBoxTextChanged;
             }
-            ScrollViewer.SetHorizontalScrollBarVisibility(_logBox, ScrollBarVisibility.Auto);
-            ScrollViewer.SetVerticalScrollBarVisibility(_logBox, ScrollBarVisibility.Auto);
-            _logBox.TextChanged += OnLogBoxTextChanged;
 
             // --- Assemble UI Layout ---
             var topPanel = _window.FindControl<DockPanel>("TopPanel");

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -32,11 +32,9 @@ public class MacroPlugin : IPlugin
     // Explicitly qualify Avalonia types to avoid conflicts with
     // Windows Forms global using directives when building for
     // net8.0-windows.
-    private Avalonia.Controls.ListBox? _macroList;
-    private Avalonia.Controls.TextBox? _nameBox;
-    private Avalonia.Controls.TextBox? _repeatBox;
-    private Avalonia.Controls.TextBlock? _status;
-    private Avalonia.Controls.Button? _playButton;
+    // Use aliases for Avalonia controls to avoid clashes with WinForms when
+    // targeting net8.0-windows. Keep a single set of fields using the alias
+    // types so the declarations are platform agnostic.
     private AvaloniaListBox? _macroList;
     private AvaloniaTextBox? _nameBox;
     private AvaloniaTextBox? _repeatBox;
@@ -136,8 +134,6 @@ public class MacroPlugin : IPlugin
                         {
 #if WINDOWS
                             // Windows uses SendKeys for playback.
-                            System.Windows.Forms.SendKeys.SendWait(key);
-
                             SendKeys.SendWait(key);
 #endif
                         }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Examples live under [`docs/examples/`](docs/examples/).
 * Skinnable widgets surface plugin features directly on the desktop.
 * Window effects like wobbly windows or drop shadows are plugin friendly.
 * Optional auto-update helper swaps in new versions using a checksum.
+
+## Building
+
+Ensure the .NET 8 SDK is installed. Compile the main application with:
+
+```bash
+dotnet build Cycloside/Cycloside.csproj
+```
+
+The build targets both `net8.0` and `net8.0-windows` and should finish with no warnings.
+
 ---
 
 ## FUTURE TODO


### PR DESCRIPTION
## Summary
- use aliases for Avalonia controls in `MacroPlugin`
- initialize log viewer controls only when available
- switch to `RadiusX`/`RadiusY` in `MainWindow`
- document .NET 8 build instructions

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo`


------
https://chatgpt.com/codex/tasks/task_e_685ea565a64083329c27ed2f885e0131