### PR TITLE
Improve plugin SDK docs

### DIFF
--- a/Cycloside/SDK/README.md
+++ b/Cycloside/SDK/README.md
@@ -1,0 +1,16 @@
+# Cycloside Plugin SDK
+
+This folder contains the minimal interfaces needed to build external plugins.
+Reference `Cycloside.dll` and implement `Cycloside.Plugins.IPlugin`.
+
+## Getting Started
+
+1. Run `dotnet run -- --newplugin MyPlugin` from the repository root to generate
+a template plugin inside `Plugins/`.
+2. Implement the methods in the generated class and compile it into its own DLL.
+3. Place the compiled DLL back in the `Plugins/` folder and use **Settings →
+Plugin Manager** to enable or disable it.
+
+See `docs/plugin-dev.md` for more details on the plugin lifecycle, bus and
+marketplace.
+

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -1,6 +1,25 @@
 # Plugin Development
 
-Cycloside supports drop-in plugins written as DLLs or volatile scripts.
+Cycloside supports drop‑in plugins written as DLLs or as in‑memory scripts.
+
+Plugins implement the `IPlugin` interface which exposes the following
+properties and methods:
+
+```csharp
+public interface IPlugin
+{
+    string Name { get; }
+    string Description { get; }
+    Version Version { get; }
+    Cycloside.Widgets.IWidget? Widget { get; }
+    bool ForceDefaultTheme { get; }
+    void Start();
+    void Stop();
+}
+```
+
+Additional hooks like `OnSettingsSaved()` and `OnCrash(Exception ex)` can be
+implemented by inheriting `IPluginExtended`.
 
 ## DLL Plugins
 
@@ -18,6 +37,19 @@ Lua (`.lua`) and C# script (`.csx`) files can be executed in memory. Use the tra
 ## Metadata
 
 Each plugin should expose `Name`, `Description` and `Version`. The plugin manager uses these to display information in the GUI.
+
+## Communication
+
+Plugins can talk to one another using the global `PluginBus`:
+
+```csharp
+PluginBus.Subscribe("my:event", data => Handle(data));
+PluginBus.Publish("my:event", payload);
+```
+
+The optional `RemoteApiServer` publishes bus events over HTTP. POST a topic name
+to `http://localhost:4123/trigger` with `X-Api-Token` or a `token` query
+parameter. See `docs/plugin-lifecycle.md` for details.
 
 ## Marketplace
 


### PR DESCRIPTION
## Summary
- expand plugin development guide with interface details
- add section on plugin communication and HTTP API
- document how to use the SDK via new README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685eacf851448332b11f9bcdf419d211