### PR TITLE
Implement basic Terminal plugin

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -129,6 +129,7 @@ public partial class App : Application
         manager.AddPlugin(new ProcessMonitorPlugin());
         manager.AddPlugin(new TaskSchedulerPlugin());
         manager.AddPlugin(new DiskUsagePlugin());
+        manager.AddPlugin(new TerminalPlugin());
         manager.AddPlugin(new LogViewerPlugin());
         manager.AddPlugin(new EnvironmentEditorPlugin());
         manager.AddPlugin(new JezzballPlugin());

--- a/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
@@ -1,0 +1,132 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Cycloside.Services;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public class TerminalPlugin : IPlugin
+{
+    private TerminalWindow? _window;
+    private TextBox? _outputBox;
+    private TextBox? _inputBox;
+    private readonly List<string> _history = new();
+    private int _historyIndex = -1;
+
+    public string Name => "Terminal";
+    public string Description => "Run shell commands";
+    public Version Version => new(0, 1, 0);
+    public Widgets.IWidget? Widget => null;
+    public bool ForceDefaultTheme => false;
+
+    public void Start()
+    {
+        _window = new TerminalWindow();
+        _outputBox = _window.FindControl<TextBox>("OutputBox");
+        _inputBox = _window.FindControl<TextBox>("InputBox");
+        if (_outputBox != null)
+        {
+            ScrollViewer.SetVerticalScrollBarVisibility(_outputBox, ScrollBarVisibility.Auto);
+        }
+        var runButton = _window.FindControl<Button>("RunButton");
+        runButton?.AddHandler(Button.ClickEvent, (_, __) => ExecuteCommand());
+        if (_inputBox != null)
+        {
+            _inputBox.KeyDown += OnInputKeyDown;
+        }
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(TerminalPlugin));
+        _window.Show();
+    }
+
+    public void Stop()
+    {
+        _window?.Close();
+        _window = null;
+    }
+
+    private void OnInputKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            ExecuteCommand();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Up)
+        {
+            if (_history.Count == 0) return;
+            _historyIndex = Math.Clamp(_historyIndex - 1, 0, _history.Count - 1);
+            _inputBox!.Text = _history[_historyIndex];
+            _inputBox.CaretIndex = _inputBox.Text.Length;
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down)
+        {
+            if (_history.Count == 0) return;
+            _historyIndex = Math.Clamp(_historyIndex + 1, 0, _history.Count - 1);
+            _inputBox!.Text = _history[_historyIndex];
+            _inputBox.CaretIndex = _inputBox.Text.Length;
+            e.Handled = true;
+        }
+    }
+
+    private void ExecuteCommand()
+    {
+        if (_inputBox == null || _outputBox == null) return;
+        var cmd = _inputBox.Text;
+        if (string.IsNullOrWhiteSpace(cmd)) return;
+
+        _history.Add(cmd);
+        _historyIndex = _history.Count;
+
+        AppendOutput($"> {cmd}\n");
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = GetShell(),
+                Arguments = GetShellArguments(cmd),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process != null)
+            {
+                var stdout = process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                if (!string.IsNullOrEmpty(stdout)) AppendOutput(stdout);
+                if (!string.IsNullOrEmpty(stderr)) AppendOutput(stderr);
+            }
+        }
+        catch (Exception ex)
+        {
+            AppendOutput($"Error: {ex.Message}\n");
+        }
+        finally
+        {
+            _inputBox.Text = string.Empty;
+        }
+    }
+
+    private void AppendOutput(string text)
+    {
+        if (_outputBox == null) return;
+        _outputBox.Text += text;
+        _outputBox.CaretIndex = _outputBox.Text.Length;
+    }
+
+    private static string GetShell()
+    {
+        return OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/bash";
+    }
+
+    private static string GetShellArguments(string command)
+    {
+        return OperatingSystem.IsWindows() ? $"/C {command}" : $"-c \"{command}\"";
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml
@@ -1,0 +1,17 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Cycloside.Plugins.BuiltIn.TerminalWindow"
+        Title="Terminal"
+        Width="700" Height="500">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" Spacing="5" Margin="5">
+            <TextBox x:Name="InputBox" Width="600" />
+            <Button x:Name="RunButton" Content="Run" />
+        </StackPanel>
+        <TextBox x:Name="OutputBox"
+                 AcceptsReturn="True"
+                 IsReadOnly="True"
+                 FontFamily="monospace"
+                 Margin="5" />
+    </DockPanel>
+</Window>

--- a/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public partial class TerminalWindow : Window
+{
+    public TerminalWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/Cycloside/TODO.md
+++ b/Cycloside/TODO.md
@@ -26,9 +26,9 @@ This is a development checklist for your Avalonia-powered hacker’s paradise ap
     - [ ] TreeView/ListView for file system
     - [ ] Context menu (Open, Rename, Delete, etc.)
     - [ ] “Open in Code Editor” action
-- [ ] **Terminal Emulator Plugin**
-    - [ ] Shell command execution
-    - [ ] Command history (arrow keys)
+- [~] **Terminal Emulator Plugin**
+    - [x] Shell command execution
+    - [x] Command history (arrow keys)
     - [ ] Styled output (color text, scrollback)
 - [ ] **Network Tools Plugin**
     - [ ] Ping, traceroute utilities


### PR DESCRIPTION
## Summary
- create `TerminalPlugin` with basic shell command execution
- add terminal window XAML for UI
- register plugin in `App.axaml.cs`
- mark Terminal emulator tasks as started in `TODO.md`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v:m`

------
https://chatgpt.com/codex/tasks/task_e_685ed757dc4c83329bd9a0d9a4748c6b