### PR TITLE
Fix plugin reload watcher

### DIFF
--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -147,9 +147,11 @@ namespace Cycloside.Plugins
                 GC.WaitForPendingFinalizers();
 
                 LoadPlugins();
+                StartWatching();
                 _notify?.Invoke("Plugins have been reloaded.");
-                
-                // Re-apply settings to the newly loaded plugins
+
+                // Re-apply settings to the newly loaded plugins so reloaded
+                // plugins are enabled or disabled based on the active profile.
                 WorkspaceProfiles.Apply(SettingsManager.Settings.ActiveProfile, this);
             }
         }


### PR DESCRIPTION
## Summary
- recreate `FileSystemWatcher` when reloading plugins
- reapply the active profile after restarting the watcher

## Testing
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68623d002db0833287d18e10c2bd4325