### PR TITLE
Add context menu to clipboard manager

### DIFF
--- a/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
@@ -37,6 +37,15 @@ namespace Cycloside.Plugins.BuiltIn
         /// </summary>
         public ObservableCollection<string> History { get; } = new();
 
+        [ObservableProperty]
+        private string? _selectedEntry;
+
+        partial void OnSelectedEntryChanged(string? value)
+        {
+            CopySelectedCommand.NotifyCanExecuteChanged();
+            DeleteSelectedCommand.NotifyCanExecuteChanged();
+        }
+
         // --- Plugin Lifecycle & Disposal ---
 
         public void Start()
@@ -76,6 +85,28 @@ namespace Cycloside.Plugins.BuiltIn
                 await clipboard.SetTextAsync(selectedText);
             }
         }
+
+        [RelayCommand(CanExecute = nameof(HasSelection))]
+        private async Task CopySelected()
+        {
+            if (string.IsNullOrEmpty(SelectedEntry)) return;
+
+            var clipboard = Application.Current?.GetMainTopLevel()?.Clipboard;
+            if (clipboard != null)
+            {
+                await clipboard.SetTextAsync(SelectedEntry);
+            }
+        }
+
+        [RelayCommand(CanExecute = nameof(HasSelection))]
+        private void DeleteSelected()
+        {
+            if (string.IsNullOrEmpty(SelectedEntry)) return;
+            History.Remove(SelectedEntry);
+            SelectedEntry = null;
+        }
+
+        private bool HasSelection() => !string.IsNullOrEmpty(SelectedEntry);
 
         // --- Private Logic ---
 

--- a/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
@@ -9,8 +9,17 @@
         Width="300"
         Height="450">
   
-  <ListBox ItemsSource="{Binding History}"
+  <ListBox x:Name="HistoryList"
+           ItemsSource="{Binding History}"
+           SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
            SelectionMode="Single"
-           DoubleTapped="ListBox_DoubleTapped" />
+           DoubleTapped="ListBox_DoubleTapped">
+    <ListBox.ContextMenu>
+      <ContextMenu>
+        <MenuItem Header="Copy" Command="{Binding CopySelectedCommand}"/>
+        <MenuItem Header="Delete" Command="{Binding DeleteSelectedCommand}"/>
+      </ContextMenu>
+    </ListBox.ContextMenu>
+  </ListBox>
   
 </Window>


### PR DESCRIPTION
## Summary
- add SelectedEntry property and commands to manipulate clipboard history
- provide context menu for copy/delete in `ClipboardManagerWindow`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68623d04c860833283c0ddb810c9424e