### PR TITLE
Ensure plugin states restored after reload

### DIFF
--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -83,6 +83,8 @@ namespace Cycloside.Plugins
             _watcher.Changed += eventHandler;
             _watcher.Deleted += eventHandler;
             _watcher.Renamed += new RenamedEventHandler((s, e) => _reloadTimer.Change(500, Timeout.Infinite));
+
+            ApplyEnabledSettings();
         }
 
         public void LoadPlugins()
@@ -148,9 +150,11 @@ namespace Cycloside.Plugins
 
                 LoadPlugins();
                 _notify?.Invoke("Plugins have been reloaded.");
-                
+
                 // Re-apply settings to the newly loaded plugins
                 WorkspaceProfiles.Apply(SettingsManager.Settings.ActiveProfile, this);
+
+                ApplyEnabledSettings();
             }
         }
 
@@ -252,6 +256,18 @@ namespace Cycloside.Plugins
 
         public bool IsEnabled(IPlugin plugin) => GetInfo(plugin)?.IsEnabled ?? false;
         public PluginChangeStatus GetStatus(IPlugin plugin) => GetInfo(plugin)?.Status ?? PluginChangeStatus.None;
+
+        private void ApplyEnabledSettings()
+        {
+            var enabled = SettingsManager.Settings.PluginEnabled;
+            foreach (var info in _pluginInfos)
+            {
+                if (enabled.TryGetValue(info.Instance.Name, out var shouldEnable) && shouldEnable)
+                {
+                    EnablePlugin(info.Instance);
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- enable stored plugins when watching starts
- re-apply enabled settings after plugin reload
- add helper to apply settings

## Testing
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68623d0d2a108332b929b40d38e64fa8