### PR TITLE
Add TextEditor buttons

### DIFF
--- a/Cycloside/Plugins/BuiltIn/Views/TextEditorWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/TextEditorWindow.axaml
@@ -1,10 +1,21 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Cycloside.Plugins.BuiltIn"
         x:Class="Cycloside.Plugins.BuiltIn.TextEditorWindow"
+        x:DataType="local:TextEditorPlugin"
         Title="Cycloside Editor - Untitled"
         Width="700" Height="550">
     <DockPanel>
-        <StackPanel x:Name="ButtonPanel" Orientation="Horizontal" Spacing="5" Margin="5" DockPanel.Dock="Top" />
+        <StackPanel x:Name="ButtonPanel"
+                    Orientation="Horizontal"
+                    Spacing="5"
+                    Margin="5"
+                    DockPanel.Dock="Top">
+            <Button Content="New" Command="{Binding NewFileCommand}" />
+            <Button Content="Open" Command="{Binding OpenFileCommand}" />
+            <Button Content="Save" Command="{Binding SaveFileCommand}" />
+            <Button Content="Save As" Command="{Binding SaveFileAsCommand}" />
+        </StackPanel>
         <Border x:Name="StatusBar" DockPanel.Dock="Bottom" Height="24" Background="CornflowerBlue">
             <TextBlock x:Name="StatusBlock" Margin="5" VerticalAlignment="Center" />
         </Border>


### PR DESCRIPTION
## Summary
- add namespace and `x:DataType` to `TextEditorWindow`
- add New/Open/Save/Save As buttons bound to plugin commands

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_68623d29978c8332a02a6684e84ce887