### PR TITLE
Ensure DiskUsage UI updates are marshalled to Dispatcher

### DIFF
--- a/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
@@ -64,8 +64,11 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 // Disable button and show a loading message to provide user feedback.
                 _selectFolderButton.IsEnabled = false;
-                _tree.ItemsSource = null; // Clear previous results
-                _statusText.Text = $"Analyzing '{path}'... (This may take a while)";
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    _tree.ItemsSource = null; // Clear previous results
+                    _statusText.Text = $"Analyzing '{path}'... (This may take a while)";
+                });
 
                 try
                 {


### PR DESCRIPTION
## Summary
- ensure updates to the disk usage window's status text and tree happen via `Dispatcher.UIThread`
- keep directory scanning on a background thread and marshal results back to the UI

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68623d34abc08332bb9e8425ecf736c1