### PR TITLE
Add log saving feature to FileWatcher

### DIFF
--- a/Cycloside/Plugins/BuiltIn/Views/FileWatcherWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/FileWatcherWindow.axaml
@@ -7,6 +7,7 @@
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" DockPanel.Dock="Top">
             <Button x:Name="SelectFolderButton" Content="Select Folder to Watch" Margin="5"/>
             <Button x:Name="ClearLogButton" Content="Clear Log" Margin="5,0,5,5"/>
+            <Button x:Name="SaveLogButton" Content="Save Log" Margin="0,0,5,5"/>
         </StackPanel>
         <TextBox x:Name="LogBox" AcceptsReturn="True" IsReadOnly="True" Margin="5"/>
     </DockPanel>


### PR DESCRIPTION
## Summary
- add **Save Log** button in `FileWatcherWindow.axaml`
- implement `SaveLogAsync` to save the log contents via `SaveFilePicker`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68623d38007c8332bfca6b054837b338