### PR TITLE
Fix EnvironmentEditor data grid setup

### DIFF
--- a/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
@@ -37,7 +37,11 @@ namespace Cycloside.Plugins.BuiltIn
                 _scopeSelector.SelectionChanged += (s, e) => LoadVariables();
             }
 
-            addButton?.AddHandler(Button.ClickEvent, (_, _) => _items.Add(new EnvItem { Key = "NEW_VARIABLE", Value = "new value" }));
+            addButton?.AddHandler(Button.ClickEvent, (_, _) =>
+            {
+                _items.Add(new EnvItem { Key = "NEW_VARIABLE", Value = "new value" });
+                SaveVariables();
+            });
             removeButton?.AddHandler(Button.ClickEvent, (_, _) =>
             {
                 if (_grid?.SelectedItem is EnvItem selectedItem)
@@ -51,8 +55,6 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 _grid.ItemsSource = _items;
                 _grid.AutoGenerateColumns = false;
-                _grid.Columns.Add(new DataGridTextColumn { Header = "Key", Binding = new Avalonia.Data.Binding("Key"), Width = new DataGridLength(1, DataGridLengthUnitType.Star) });
-                _grid.Columns.Add(new DataGridTextColumn { Header = "Value", Binding = new Avalonia.Data.Binding("Value"), Width = new DataGridLength(2, DataGridLengthUnitType.Star) });
             }
 
             LoadVariables();

--- a/Cycloside/Plugins/BuiltIn/Views/EnvironmentEditorWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/EnvironmentEditorWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Cycloside.Plugins.BuiltIn.EnvironmentEditorWindow"
+        x:CompileBindings="False"
         Title="Environment Variables Editor"
         Width="700" Height="500">
     <DockPanel>
@@ -11,6 +12,11 @@
             <Button x:Name="RemoveButton" Content="Remove"/>
             <Button x:Name="SaveButton" Content="Save Changes"/>
         </StackPanel>
-        <DataGrid x:Name="Grid"/>
+        <DataGrid x:Name="Grid" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Key" Binding="{Binding Path=Key, Mode=TwoWay}" IsReadOnly="False" Width="*" />
+                <DataGridTextColumn Header="Value" Binding="{Binding Path=Value, Mode=TwoWay}" IsReadOnly="False" Width="2*" />
+            </DataGrid.Columns>
+        </DataGrid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- define editable columns directly in `EnvironmentEditorWindow.axaml`
- disable compiled bindings in the environment editor view
- call `SaveVariables` when a new entry is added

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68623d4674e883329ca641c6c58dc41b