### PR TITLE
Ensure plugin menu items toggle individually

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -242,13 +242,17 @@ public partial class App : Application
 
         menuItem.Command = new RelayCommand(o =>
         {
-            if (manager.IsEnabled(plugin)) manager.DisablePlugin(plugin);
-            else manager.EnablePlugin(plugin);
-            
-            menuItem.IsChecked = manager.IsEnabled(plugin);
-            settings.PluginEnabled[plugin.Name] = menuItem.IsChecked;
+            var item = (NativeMenuItem)o!;
+            if (manager.IsEnabled(plugin))
+                manager.DisablePlugin(plugin);
+            else
+                manager.EnablePlugin(plugin);
+
+            item.IsChecked = manager.IsEnabled(plugin);
+            settings.PluginEnabled[plugin.Name] = item.IsChecked;
             SettingsManager.Save();
         });
+        menuItem.CommandParameter = menuItem;
 
         return menuItem;
     }


### PR DESCRIPTION
## Summary
- correct plugin menu item command in `BuildPluginMenuItem`
- each tray menu item now passes itself as the command parameter

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68623d1c9cfc8332a105b051c5fb8217