### PR TITLE
Fix plugin issues and update docs

### DIFF
--- a/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
@@ -32,8 +32,16 @@ namespace Cycloside.Plugins.BuiltIn
 
             if (_scopeSelector != null)
             {
-                _scopeSelector.ItemsSource = Enum.GetValues(typeof(EnvironmentVariableTarget));
-                _scopeSelector.SelectedIndex = (int)EnvironmentVariableTarget.User;
+                var targets = OperatingSystem.IsWindows()
+                    ? new[]
+                    {
+                        EnvironmentVariableTarget.User,
+                        EnvironmentVariableTarget.Machine,
+                        EnvironmentVariableTarget.Process
+                    }
+                    : new[] { EnvironmentVariableTarget.Process };
+                _scopeSelector.ItemsSource = targets;
+                _scopeSelector.SelectedItem = targets.First();
                 _scopeSelector.SelectionChanged += (s, e) => LoadVariables();
             }
 

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -180,10 +180,21 @@ namespace Cycloside.Plugins.BuiltIn
                 }
             }
             _wavePlayer?.Play();
+            if (_wavePlayer != null)
+            {
+                IsPlaying = true;
+            }
         }
 
         [RelayCommand(CanExecute = nameof(IsPlaying))]
-        private void Pause() => _wavePlayer?.Pause();
+        private void Pause()
+        {
+            if (_wavePlayer != null)
+            {
+                _wavePlayer.Pause();
+                IsPlaying = false;
+            }
+        }
 
         [RelayCommand(CanExecute = nameof(IsPlaying))]
         private void Stop() => CleanupPlayback();

--- a/README-dev.md
+++ b/README-dev.md
@@ -28,7 +28,7 @@ planned features for the Cycloside project.
   broadcasts changes on `bus:clipboard`. |
 | `DateTimeOverlayPlugin` | Small always-on-top window showing the current time. |
 | `DiskUsagePlugin` | Visualises folder sizes in a tree view. |
-| `EnvironmentEditorPlugin` | Edits environment variables at runtime. |
+| `EnvironmentEditorPlugin` | Edits environment variables at runtime (Process scope only on Linux/macOS). |
 | `FileWatcherPlugin` | Watches a directory and logs file system events. |
 | `JezzballPlugin` | Simple recreation of the classic game. |
 | `LogViewerPlugin` | Tails a log file and filters lines on the fly. |

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -70,3 +70,8 @@ foreach (var p in plugins)
 - [Skin Example](examples/skin-example.md)
 - [Custom Cursor Example](examples/custom-cursor-example.md)
 
+## Notes
+
+`EnvironmentEditorPlugin` lists environment variables from the selected scope.
+On Linux and macOS only the `Process` scope is available.
+


### PR DESCRIPTION
## Summary
- start the progress timer by updating `IsPlaying` when playback begins
- ensure `Pause` resets `IsPlaying`
- use supported scopes in `EnvironmentEditorPlugin` and default to `Process` on non-Windows
- document environment editor platform limits

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_686242c04b648332bcaf4b9234c2cc48