### PR TITLE
Fix plugin list in main window menu

### DIFF
--- a/Cycloside/MainWindow.axaml
+++ b/Cycloside/MainWindow.axaml
@@ -26,21 +26,19 @@
                 <!-- The Exit command will be handled by the ViewModel -->
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
             </MenuItem>
-            <MenuItem Header="_Plugins">
-                <!-- 
-                  This is the dynamic menu for your plugins.
-                  It binds to an "AvailablePlugins" collection in the ViewModel.
-                  For each plugin, it creates a new menu item.
+            <MenuItem Header="_Plugins"
+                      ItemsSource="{Binding AvailablePlugins}">
+                <!--
+                  Dynamically generate a menu item for each available plugin.
+                  Each item invokes the StartPluginCommand when clicked.
                 -->
-                <ItemsControl ItemsSource="{Binding AvailablePlugins}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="p:IPlugin">
-                            <MenuItem Header="{Binding Name}"
-                                      Command="{Binding DataContext.StartPluginCommand, ElementName=RootWindow}"
-                                      CommandParameter="{Binding}" />
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
+                <MenuItem.ItemTemplate>
+                    <DataTemplate x:DataType="p:IPlugin">
+                        <MenuItem Header="{Binding Name}"
+                                  Command="{Binding DataContext.StartPluginCommand, ElementName=RootWindow}"
+                                  CommandParameter="{Binding}" />
+                    </DataTemplate>
+                </MenuItem.ItemTemplate>
             </MenuItem>
         </Menu>
 


### PR DESCRIPTION
## Summary
- bind plugin list directly to MenuItem.ItemsSource so each plugin creates its own clickable entry

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862a85cf9cc83328e70cfc9bc07191f