### PR TITLE
Fix theme load fallback and expand theme settings

### DIFF
--- a/Cycloside/Services/ThemeManager.cs
+++ b/Cycloside/Services/ThemeManager.cs
@@ -26,23 +26,28 @@ namespace Cycloside.Services
             {
                 themeName = "MintGreen";
             }
-            
-            LoadGlobalTheme(themeName);
+
+            // Attempt to load the requested theme. If it fails (e.g. file
+            // missing) fall back to the default so the UI is always styled.
+            if (!LoadGlobalTheme(themeName) && themeName != "MintGreen")
+            {
+                LoadGlobalTheme("MintGreen");
+            }
         }
 
         /// <summary>
         /// Applies a single global theme to the entire application.
         /// It clears any previously loaded global theme first.
         /// </summary>
-        public static void LoadGlobalTheme(string themeName)
+        public static bool LoadGlobalTheme(string themeName)
         {
-            if (Application.Current == null) return;
+            if (Application.Current == null) return false;
 
             var file = Path.Combine(GlobalThemeDir, $"{themeName}.axaml");
             if (!File.Exists(file))
             {
                 Logger.Log($"Global theme '{themeName}' not found at '{file}'.");
-                return;
+                return false;
             }
 
             // Remove any existing global theme to prevent conflicts
@@ -60,6 +65,7 @@ namespace Cycloside.Services
             Application.Current.Styles.Add(newThemeStyle);
             SettingsManager.Settings.GlobalTheme = themeName; // Save the active theme
             SettingsManager.Save();
+            return true;
         }
 
         /// <summary>

--- a/Cycloside/ThemeSettingsWindow.axaml.cs
+++ b/Cycloside/ThemeSettingsWindow.axaml.cs
@@ -8,7 +8,30 @@ namespace Cycloside;
 
 public partial class ThemeSettingsWindow : Window
 {
-    private readonly string[] _components = new[] { "Cycloside", "TextEditor", "MediaPlayer", "Plugins" };
+    // Expanded list of components so all built-in plugins can have skins
+    // assigned through the settings UI.
+    private readonly string[] _components = new[]
+    {
+        "Cycloside",
+        "Text Editor",
+        "MP3 Player",
+        "Terminal",
+        "Macro Engine",
+        "Process Monitor",
+        "Wallpaper Changer",
+        "Clipboard Manager",
+        "Date/Time Overlay",
+        "Disk Usage",
+        "Environment Editor",
+        "File Watcher",
+        "Jezzball",
+        "Log Viewer",
+        "QBasic Retro IDE",
+        "Task Scheduler",
+        "Widget Host",
+        "Winamp Visual Host",
+        "Plugins"
+    };
     private readonly string[] _themes = new[] { "MintGreen", "Matrix", "Orange", "ConsoleGreen", "MonochromeOrange", "DeepBlue" };
     private readonly Dictionary<string, (CheckBox cb, ComboBox box)> _controls = new();
 


### PR DESCRIPTION
## Summary
- ensure LoadGlobalThemeFromSettings falls back to MintGreen theme when configured theme isn't found
- make LoadGlobalTheme return a bool for success
- list all built‑in plugins in ThemeSettingsWindow so skins can be assigned

## Testing
- `dotnet build Cycloside/Cycloside.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_6862a97555088332b39611f7cf56461d