### PR TITLE
Fix ThemeSettingsWindow call

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -82,7 +82,7 @@ public partial class App : Application
         
         // --- View & ViewModel Creation ---
         var viewModel = new MainWindowViewModel(manager.Plugins);
-        var mainWindow = new MainWindow
+        var mainWindow = new MainWindow(manager)
         {
             DataContext = viewModel
         };

--- a/Cycloside/MainWindow.axaml.cs
+++ b/Cycloside/MainWindow.axaml.cs
@@ -1,13 +1,27 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Cycloside.Plugins;
 using Cycloside.Services;
 
 namespace Cycloside;
 
 public partial class MainWindow : Window
 {
+    private readonly PluginManager _manager;
+
+    // Parameterless constructor for designer support
     public MainWindow()
     {
+        InitializeComponent();
+        _manager = null!;
+        ThemeManager.ApplyFromSettings(this, nameof(MainWindow));
+        CursorManager.ApplyFromSettings(this, nameof(MainWindow));
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(this, nameof(MainWindow));
+    }
+
+    public MainWindow(PluginManager manager)
+    {
+        _manager = manager;
         InitializeComponent();
         ThemeManager.ApplyFromSettings(this, nameof(MainWindow));
         CursorManager.ApplyFromSettings(this, nameof(MainWindow));
@@ -15,7 +29,7 @@ public partial class MainWindow : Window
     }
 
     private void OpenThemeSettings(object? sender, RoutedEventArgs e) =>
-        new ThemeSettingsWindow().Show();
+        new ThemeSettingsWindow(_manager).Show();
 
     private void OpenSkinEditor(object? sender, RoutedEventArgs e) =>
         new SkinThemeEditorWindow().Show();


### PR DESCRIPTION
## Summary
- pass `PluginManager` through `MainWindow` to fix build error when opening Theme Settings
- update `App` to construct `MainWindow` with the manager

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862b186b72c8332b6cca725f72ee61b