### PR TITLE
Improve Cycloside docs and starter assets

### DIFF
--- a/Cycloside/SDK/README.md
+++ b/Cycloside/SDK/README.md
@@ -2,14 +2,18 @@
 
 This folder contains the minimal interfaces needed to build external plugins.
 Reference `Cycloside.dll` and implement `Cycloside.Plugins.IPlugin`.
+The interface exposes metadata, lifecycle methods and an optional `Widget`
+surface for dockable controls. For advanced hooks implement
+`IPluginExtended`.
 
 ## Getting Started
 
 1. Run `dotnet run -- --newplugin MyPlugin` from the repository root to generate
-a template plugin inside `Plugins/`.
+   a template plugin inside `Plugins/`.
 2. Implement the methods in the generated class and compile it into its own DLL.
 3. Place the compiled DLL back in the `Plugins/` folder and use **Settings →
-Plugin Manager** to enable or disable it.
+   Plugin Manager** to enable or disable it. Dependencies should sit beside the
+   DLL.
 
 See `docs/plugin-dev.md` for more details on the plugin lifecycle, bus and
 marketplace.

--- a/Cycloside/Skins/Blank.axaml
+++ b/Cycloside/Skins/Blank.axaml
@@ -1,0 +1,3 @@
+<Styles xmlns="https://github.com/avaloniaui">
+  <!-- Override specific controls here -->
+</Styles>

--- a/Cycloside/Themes/Global/Blank.axaml
+++ b/Cycloside/Themes/Global/Blank.axaml
@@ -1,0 +1,5 @@
+<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Styles.Resources>
+    <!-- Define colors and brushes here -->
+  </Styles.Resources>
+</Styles>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ Cycloside is a small cross‑platform tray application built for tinkerers. It h
 2. Open **Skin/Theme Editor** to modify `.axaml` theme files or cursor choices.
 3. Toggle window effects or enable/disable plugins as desired.
 4. Themes and plugin settings are stored in `settings.json` next to the executable.
+   Use the provided `Blank.axaml` theme and skin as starting points in
+   `Cycloside/Themes/Global/` and `Cycloside/Skins/`.
 
 For plugin development details see [`docs/plugin-dev.md`](docs/plugin-dev.md).
 Examples live under [`docs/examples/`](docs/examples/).
 
 ## Features
+
+<details><summary>Core</summary>
 
 * Built-in plugin system with hot reload. Sample modules include a clock overlay,
   MP3 player, macro recorder (Windows only), text editor, wallpaper changer, widget host and
@@ -49,6 +53,31 @@ Examples live under [`docs/examples/`](docs/examples/).
 * Skinnable widgets surface plugin features directly on the desktop.
 * Window effects like wobbly windows or drop shadows are plugin friendly.
 * Optional auto-update helper swaps in new versions using a checksum.
+
+</details>
+
+<details><summary>Built-in Plugins</summary>
+
+| Plugin | Description |
+| ------ | ----------- |
+| `ClipboardManagerPlugin` | Stores clipboard history in a window and broadcasts changes on `bus:clipboard`. |
+| `DateTimeOverlayPlugin` | Small always-on-top window showing the current time. |
+| `DiskUsagePlugin` | Visualises folder sizes in a tree view. |
+| `EnvironmentEditorPlugin` | Edits environment variables at runtime (Process scope only on Linux/macOS). |
+| `FileWatcherPlugin` | Watches a directory and logs file system events. |
+| `JezzballPlugin` | Simple recreation of the classic game. |
+| `LogViewerPlugin` | Tails a log file and filters lines on the fly. |
+| `MP3PlayerPlugin` | Basic audio player built on NAudio. |
+| `MacroPlugin` | Records keyboard macros and saves them to disk. Playback is Windows-only. |
+| `ProcessMonitorPlugin` | Lists running processes with CPU and memory usage. |
+| `QBasicRetroIDEPlugin` | Minimal IDE for creating QBasic-style programs. Includes an option to launch QB64 for editing. |
+| `TaskSchedulerPlugin` | Schedules tasks with cron-style expressions. |
+| `TextEditorPlugin` | Notepad-like editor supporting multiple files. |
+| `WallpaperPlugin` | Changes the desktop wallpaper periodically. |
+| `WidgetHostPlugin` | Hosts small widgets inside dockable panels. |
+| `WinampVisHostPlugin` | Runs Winamp AVS visualisation presets. |
+
+</details>
 
 ## Building
 

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -21,9 +21,25 @@ public interface IPlugin
 Additional hooks like `OnSettingsSaved()` and `OnCrash(Exception ex)` can be
 implemented by inheriting `IPluginExtended`.
 
+## Exposed Utilities
+
+Plugins can call into several helper classes shipped with the main application:
+
+- `PluginBus` – simple publish/subscribe message bus for cross-plugin
+  communication.
+- `SkinManager` and `ThemeManager` – apply XAML skins and themes at runtime.
+- `CursorManager` – assign `StandardCursorType` values from settings.
+- `WindowEffectsManager` – enable compositor/physics effects on a window.
+- `PluginMarketplace` – fetch and install plugin packages from remote feeds.
+
+These classes live in the `Cycloside` namespace and are available when you
+reference `Cycloside.dll`.
+
 ## DLL Plugins
 
 Implement `Cycloside.Plugins.IPlugin` and place the compiled assembly in the `Plugins/` directory. Hot reload will load changes automatically.
+When compiled, each plugin resides in its own folder under `Plugins/`.
+Dependencies should be copied alongside the main DLL.
 
 You can generate a boilerplate plugin with:
 ```bash
@@ -37,6 +53,9 @@ Lua (`.lua`) and C# script (`.csx`) files can be executed in memory. Use the tra
 ## Metadata
 
 Each plugin should expose `Name`, `Description` and `Version`. The plugin manager uses these to display information in the GUI.
+If your plugin exposes a dockable widget, return an `IWidget` implementation via
+the `Widget` property. Set `ForceDefaultTheme` to `true` if your UI should always
+use the global theme and ignore component skins.
 
 ## Communication
 

--- a/docs/theming-skinning.md
+++ b/docs/theming-skinning.md
@@ -23,6 +23,24 @@ it with `CursorManager.ApplyFromSettings`. Values correspond to
 `StandardCursorType` names (e.g. `Arrow`, `Hand`, `Ibeam`). Windows and plugins
 can supply their own cursor via skins or themes as needed.
 
+### Blank Theme/Skin
+
+The repository includes `Blank.axaml` files in both `Cycloside/Themes/Global/`
+and `Cycloside/Skins/`. Copy these as a starting point for your own design.
+Each file is a minimal `<Styles>` block where you can define colors, brushes and
+styles. Example:
+
+```xml
+<Styles xmlns="https://github.com/avaloniaui">
+  <Styles.Resources>
+    <!-- add ThemeBackgroundBrush etc -->
+  </Styles.Resources>
+</Styles>
+```
+
+After saving your theme or skin, select it from **Settings → Theme Settings** or
+apply it in code via `SkinManager.ApplySkin(control, "MySkin")`.
+
 See the [theme example](examples/theme-example.md) and [skin example](examples/skin-example.md) for sample resource files. The [custom cursor example](examples/custom-cursor-example.md) shows how to configure cursors.
 
 ## Skin/Theme Editor


### PR DESCRIPTION
## Summary
- document new plugin utilities and widget notes
- clarify SDK overview
- update theming docs with blank theme/skin samples
- add Blank.axaml starter files
- restructure README with collapsible sections and mention blank theme/skin

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: Unable to find package libopenmpt-sharp)*

------
https://chatgpt.com/codex/tasks/task_e_686431c753fc8332a0390f8eeb6f4b87