### PR TITLE
Fix plugin theming handling

### DIFF
--- a/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
@@ -37,7 +37,7 @@ namespace Cycloside.Plugins.BuiltIn
 
             // Apply theming and effects (assuming these are valid managers in your project)
             
-            ThemeManager.ApplyFromSettings(_window, "Plugins");
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DiskUsagePlugin));
 
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -39,7 +39,7 @@ namespace Cycloside.Plugins.BuiltIn
                 Content = _control
             };
 
-            ThemeManager.ApplyFromSettings(_window, nameof(JezzballPlugin));
+            ThemeManager.ApplyForPlugin(_window, this);
             _window.KeyDown += OnWindowKeyDown;
             _window.Show();
         }

--- a/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
@@ -103,7 +103,7 @@ namespace Cycloside.Plugins.BuiltIn
                 Content = dock
             };
 
-            ThemeManager.ApplyFromSettings(_window, nameof(QBasicRetroIDEPlugin));
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(QBasicRetroIDEPlugin));
             _window.KeyDown += Window_KeyDown;
             _window.Opened += (_, _) => _editor?.Focus();
@@ -558,7 +558,7 @@ namespace Cycloside.Plugins.BuiltIn
                     VerticalAlignment = VerticalAlignment.Center
                 }
             };
-            ThemeManager.ApplyFromSettings(aboutWindow, nameof(QBasicRetroIDEPlugin));
+            ThemeManager.ApplyForPlugin(aboutWindow, this);
             aboutWindow.ShowDialog(_window);
         }
 

--- a/Cycloside/Plugins/BuiltIn/WallpaperPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WallpaperPlugin.cs
@@ -45,7 +45,7 @@ namespace Cycloside.Plugins.BuiltIn
                 }
             };
             PluginBus.Subscribe("wallpaper:set", _wallpaperHandler);
-            ThemeManager.ApplyFromSettings(_window, "Plugins");
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(WallpaperPlugin));
             _window.Show();
         }

--- a/Cycloside/Services/ThemeManager.cs
+++ b/Cycloside/Services/ThemeManager.cs
@@ -5,6 +5,7 @@ using Avalonia.Styling;
 using System;
 using System.IO;
 using System.Linq;
+using Cycloside.Plugins;
 
 namespace Cycloside.Services
 {
@@ -84,6 +85,23 @@ namespace Cycloside.Services
         {
             // The global theme is loaded once at startup, so we just need to apply component themes here.
             ApplyComponentTheme(window, componentName);
+        }
+
+        /// <summary>
+        /// Applies themes for a plugin window. This first applies the generic
+        /// "Plugins" theme, then the plugin specific theme using the plugin's
+        /// <see cref="IPlugin.Name"/>. If <see cref="IPlugin.ForceDefaultTheme"/>
+        /// is true, no component themes are applied.
+        /// </summary>
+        /// <param name="window">The window to theme.</param>
+        /// <param name="plugin">The plugin instance.</param>
+        public static void ApplyForPlugin(Window window, Cycloside.Plugins.IPlugin plugin)
+        {
+            if (plugin.ForceDefaultTheme)
+                return;
+
+            ApplyComponentTheme(window, "Plugins");
+            ApplyComponentTheme(window, plugin.Name);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `ThemeManager.ApplyForPlugin` to respect `ForceDefaultTheme`
- apply new helper across built‑in plugin windows

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal` *(fails: Unable to find package libopenmpt-sharp)*

------
https://chatgpt.com/codex/tasks/task_e_6864321294a083328f282af9662dbd38