### PR TITLE
Bug fixes to Cycloside plugin reload

### DIFF
--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -48,6 +48,9 @@ namespace Cycloside.Plugins
         private readonly Action<string>? _notify;
         private Timer? _reloadTimer;
 
+        // Exposed so the UI can rebuild when plugins change.
+        public event Action? PluginsReloaded;
+
         public string PluginDirectory { get; }
         public bool IsolationEnabled { get; set; }
         public bool CrashLoggingEnabled { get; set; }
@@ -151,6 +154,9 @@ namespace Cycloside.Plugins
                 LoadPlugins();
                 StartWatching();
                 _notify?.Invoke("Plugins have been reloaded.");
+
+                // Notify any listeners that plugins have changed so UI can refresh.
+                PluginsReloaded?.Invoke();
 
                 // Re-apply settings to the newly loaded plugins so reloaded
                 // plugins are enabled or disabled based on the active profile.

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -25,6 +25,10 @@ implemented by inheriting `IPluginExtended`.
 
 Implement `Cycloside.Plugins.IPlugin` and place the compiled assembly in the `Plugins/` directory. Hot reload will load changes automatically.
 
+When the plugin folder contents change, `PluginManager` reloads all plugins and
+triggers the `PluginsReloaded` event.  Subscribe to this event if your code
+needs to refresh UI elements after new plugins are detected.
+
 You can generate a boilerplate plugin with:
 ```bash
  dotnet run -- --newplugin MyPlugin


### PR DESCRIPTION
## Summary
- expose `PluginsReloaded` event in `PluginManager`
- raise the event after plugins are reloaded
- mention the event in `plugin-dev.md`

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: Unable to find package libopenmpt-sharp)*

------
https://chatgpt.com/codex/tasks/task_e_6864321294a083328f282af9662dbd38