### PR TITLE
Fix theme path and add reload event

### DIFF
--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -48,6 +48,13 @@ namespace Cycloside.Plugins
         private readonly Action<string>? _notify;
         private Timer? _reloadTimer;
 
+        /// <summary>
+        /// Raised whenever <see cref="ReloadPlugins"/> completes successfully.
+        /// The application listens to this to rebuild UI elements such as the
+        /// tray menu.
+        /// </summary>
+        public event Action? PluginsReloaded;
+
         public string PluginDirectory { get; }
         public bool IsolationEnabled { get; set; }
         public bool CrashLoggingEnabled { get; set; }
@@ -157,6 +164,9 @@ namespace Cycloside.Plugins
                 WorkspaceProfiles.Apply(SettingsManager.Settings.ActiveProfile, this);
 
                 ApplyEnabledSettings();
+
+                // Notify listeners that the plugin collection has changed.
+                PluginsReloaded?.Invoke();
             }
         }
 

--- a/Cycloside/Services/ThemeManager.cs
+++ b/Cycloside/Services/ThemeManager.cs
@@ -14,7 +14,11 @@ namespace Cycloside.Services
     /// </summary>
     public static class ThemeManager
     {
-        private static string ThemeDir => Path.Combine(AppContext.BaseDirectory, "Themes");
+        // All themes are stored under the 'Themes/Global' subdirectory. The
+        // editor and setup wizard already point there, but the ThemeManager
+        // previously used the parent directory which caused missing theme
+        // errors at runtime.
+        private static string ThemeDir => Path.Combine(AppContext.BaseDirectory, "Themes", "Global");
 
         /// <summary>
         /// Applies the application-wide global theme from settings.
@@ -52,7 +56,7 @@ namespace Cycloside.Services
 
             // Remove any existing global theme to prevent conflicts
             var existing = Application.Current.Styles.OfType<StyleInclude>()
-                .FirstOrDefault(s => s.Source?.OriginalString.Contains("/Themes/") == true);
+                .FirstOrDefault(s => s.Source?.OriginalString.Contains("/Themes/Global/") == true);
             if (existing != null)
             {
                 Application.Current.Styles.Remove(existing);


### PR DESCRIPTION
## Summary
- add `PluginsReloaded` event to `PluginManager`
- notify the event after hot reload completes
- update `ThemeManager` to use the Themes/Global directory

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal` *(fails: Unable to find package libopenmpt-sharp)*

------
https://chatgpt.com/codex/tasks/task_e_6864321294a083328f282af9662dbd38