### PR TITLE
Add LibModPlugSharp build scripts

### DIFF
--- a/LibModPlugSharp/LibModPlugSharp.csproj
+++ b/LibModPlugSharp/LibModPlugSharp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/LibModPlugSharp/ModPlugSharp.cs
+++ b/LibModPlugSharp/ModPlugSharp.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibModPlugSharp
+{
+    public class ModPlugModule : IDisposable
+    {
+        private IntPtr _handle;
+
+        public ModPlugModule(byte[] data)
+        {
+            _handle = NativeMethods.openmpt_module_create_from_memory(data, (UIntPtr)data.Length, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            if (_handle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Failed to create module");
+            }
+        }
+
+        public string GetTitle()
+        {
+            IntPtr ptr = NativeMethods.openmpt_module_get_metadata(_handle, "title");
+            return Marshal.PtrToStringAnsi(ptr) ?? string.Empty;
+        }
+
+        public int Read(float[] buffer, int sampleRate)
+        {
+            return NativeMethods.openmpt_module_read_interleaved_stereo(_handle, sampleRate, (UIntPtr)(buffer.Length / 2), buffer);
+        }
+
+        public void Dispose()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                NativeMethods.openmpt_module_destroy(_handle);
+                _handle = IntPtr.Zero;
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/LibModPlugSharp/NativeMethods.cs
+++ b/LibModPlugSharp/NativeMethods.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace LibModPlugSharp
+{
+    internal static class NativeMethods
+    {
+        private const string LibraryName = "libopenmpt";
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr openmpt_module_create_from_memory(byte[] data, UIntPtr size, IntPtr logFunc, IntPtr logUser, IntPtr ctls);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void openmpt_module_destroy(IntPtr module);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr openmpt_module_get_metadata(IntPtr module, string key);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int openmpt_module_read_interleaved_stereo(IntPtr module, int samplerate, UIntPtr count, float[] buffer);
+    }
+}

--- a/LibModPlugSharp/README.md
+++ b/LibModPlugSharp/README.md
@@ -1,0 +1,19 @@
+# LibModPlugSharp
+
+This folder contains build scripts and a simple C# wrapper for compiling
+[libopenmpt](https://lib.openmpt.org/) as a native library that can be
+consumed from .NET applications.
+
+The build steps fetch the official OpenMPT sources and produce
+`libopenmpt` for the current platform. The resulting library can then be
+accessed via P/Invoke bindings in `LibModPlugSharp.cs`.
+
+## Building
+
+1. Ensure that `cmake`, a C compiler and the .NET 8 SDK are installed.
+2. Run `./build.sh` on Linux/macOS or `build.ps1` on Windows to
+   download and compile the native library.
+3. Build the C# project with `dotnet build LibModPlugSharp.csproj`.
+
+The build scripts will place the compiled native library inside the
+`native/` folder so it can be loaded at runtime.

--- a/LibModPlugSharp/build.ps1
+++ b/LibModPlugSharp/build.ps1
@@ -1,0 +1,16 @@
+Param()
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path openmpt)) {
+    git clone --depth 1 https://github.com/OpenMPT/openmpt.git
+}
+
+New-Item -ItemType Directory -Force -Path build | Out-Null
+Push-Location build
+cmake ../openmpt -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF -DLIBOPENMPT_BUILD_TEST=OFF -DLIBOPENMPT_BUILD_EXAMPLES=OFF
+cmake --build . --config Release
+Pop-Location
+
+New-Item -ItemType Directory -Force -Path native | Out-Null
+Get-ChildItem build/bin/libopenmpt.* | Copy-Item -Destination native -Force

--- a/LibModPlugSharp/build.sh
+++ b/LibModPlugSharp/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Download OpenMPT sources if not already present
+if [ ! -d openmpt ]; then
+    git clone --depth 1 https://github.com/OpenMPT/openmpt.git
+fi
+
+mkdir -p build
+cd build
+cmake ../openmpt -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF \
+      -DLIBOPENMPT_BUILD_TEST=OFF -DLIBOPENMPT_BUILD_EXAMPLES=OFF
+cmake --build . --config Release
+
+# Copy the resulting library to the native folder
+cd ..
+mkdir -p native
+cp build/bin/libopenmpt.* native/ 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add `LibModPlugSharp` folder with README and build scripts
- provide a minimal wrapper to libopenmpt via P/Invoke

## Testing
- `dotnet build Cycloside/Cycloside.csproj -c Release` *(fails: Unable to find package libopenmpt-sharp)*
- `dotnet build LibModPlugSharp/LibModPlugSharp.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6865b596d56883329f6063e3234336a5