### PR TITLE
Add volatile scripting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Detailed instructions for creating your own look are in
 
 For plugin development details see [`docs/plugin-dev.md`](docs/plugin-dev.md).
 Examples live under [`docs/examples/`](docs/examples/).
+For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scripting.md).
 
 ## Features
 

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -60,6 +60,7 @@ You can generate a boilerplate plugin with:
 ## Volatile Scripts
 
 Lua (`.lua`) and C# script (`.csx`) files can be executed in memory. Use the tray menu **Settings → Generate New Plugin** and choose a volatile type to create a starter file.
+See [volatile-scripting.md](volatile-scripting.md) for common examples and tips.
 
 ## Metadata
 

--- a/docs/volatile-scripting.md
+++ b/docs/volatile-scripting.md
@@ -1,0 +1,62 @@
+# Volatile Scripting
+
+Cycloside can run small Lua and C# snippets directly from memory. Use this feature to prototype ideas or test behaviours without building a full plugin.
+
+## Running Scripts
+
+1. Right-click the tray icon and open the **Volatile** submenu.
+2. Choose **Run Lua Script...** or **Run C# Script...** to select a file.
+3. Use **Volatile → Inline Runner** to type code on the fly.
+4. Output from scripts is written to the log window.
+
+## Lua Examples
+
+```lua
+-- print the title of the first window
+local main = Avalonia.Application.Current.Windows[1]
+Logger.Log(main.Title)
+
+-- change the wallpaper via the wallpaper plugin
+PluginBus.Publish("wallpaper:set", "/path/to/image.jpg")
+```
+
+## C# Examples
+
+Scripts must define a `Script` class with a static `Run` method:
+
+```csharp
+using Cycloside;
+using Avalonia.Controls;
+
+public static class Script
+{
+    public static void Run()
+    {
+        Logger.Log("Hello from C# script");
+    }
+}
+```
+
+Open a simple window:
+
+```csharp
+using Cycloside;
+using Avalonia.Controls;
+
+public static class Script
+{
+    public static void Run()
+    {
+        var w = new Window { Width = 200, Height = 100, Content = "Hi" };
+        w.Show();
+    }
+}
+```
+
+## Tips
+
+- Scripts share the global `PluginBus` for communication.
+- Call `ThemeManager.LoadGlobalTheme("MyTheme")` to switch themes at runtime.
+- Keep snippets short; they are not saved after the app closes.
+
+For details on the plugin system see [plugin-dev.md](plugin-dev.md).


### PR DESCRIPTION
## Summary
- document how to run Lua and C# scripts in memory
- link to the new guide from README and plugin-dev docs

## Testing
- `dotnet --version`


------
https://chatgpt.com/codex/tasks/task_e_6865c4784cbc833295d102a91e8b154a