### PR TITLE
Fix OpenMPT build path

### DIFF
--- a/LibModPlugSharp/README.md
+++ b/LibModPlugSharp/README.md
@@ -4,8 +4,9 @@ It mirrors a subset of the libopenmpt-sharp NuGet package so the
 Cycloside project can build without external dependencies.
 
 The build.sh and build.ps1 scripts download the official OpenMPT
-sources and compile the native library. The resulting libopenmpt
-binary is placed in the native/ directory and loaded at runtime by
+sources and compile the native library using the CMake project in
+`openmpt/build`. The resulting libopenmpt binary is placed in the
+native/ directory and loaded at runtime by
 Module via P/Invoke.
 
 Building

--- a/LibModPlugSharp/build.ps1
+++ b/LibModPlugSharp/build.ps1
@@ -8,7 +8,7 @@ if (-not (Test-Path openmpt)) {
 
 New-Item -ItemType Directory -Force -Path build | Out-Null
 Push-Location build
-cmake ../openmpt -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF -DLIBOPENMPT_BUILD_TEST=OFF -DLIBOPENMPT_BUILD_EXAMPLES=OFF
+cmake ../openmpt/build -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF -DLIBOPENMPT_BUILD_TEST=OFF -DLIBOPENMPT_BUILD_EXAMPLES=OFF
 cmake --build . --config Release
 Pop-Location
 

--- a/LibModPlugSharp/build.sh
+++ b/LibModPlugSharp/build.sh
@@ -8,7 +8,7 @@ fi
 
 mkdir -p build
 cd build
-cmake ../openmpt -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF \
+cmake ../openmpt/build -DCMAKE_BUILD_TYPE=Release -DLIBOPENMPT_STATIC=OFF \
       -DLIBOPENMPT_BUILD_TEST=OFF -DLIBOPENMPT_BUILD_EXAMPLES=OFF
 cmake --build . --config Release
 


### PR DESCRIPTION
## Summary
- point build scripts at OpenMPT's `build` directory
- clarify documentation on where the CMake files live

## Testing
- `bash build.sh` *(fails: CMake config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c585fde88332a45d6f4ea2b41fd9