### PR TITLE
Add Jezzball theme and skin options

### DIFF
--- a/Cycloside/SettingsManager.cs
+++ b/Cycloside/SettingsManager.cs
@@ -26,6 +26,12 @@ public class AppSettings
     // RENAMED: This maps components (like plugin names) to specific skins.
     public Dictionary<string, string> ComponentThemes { get; set; } = new();
 
+    // Theme used by game logic inside plugins such as Jezzball
+    public Dictionary<string, string> PluginGameThemes { get; set; } = new();
+
+    // Optional skin applied to plugin windows
+    public Dictionary<string, string> PluginSkins { get; set; } = new();
+
     public string Cursor { get; set; } = "Arrow";
     public Dictionary<string, string> ComponentCursors { get; set; } = new();
     public Dictionary<string, List<string>> WindowEffects { get; set; } = new();

--- a/Cycloside/Skins/JezzballColorblindDeuteranopia.axaml
+++ b/Cycloside/Skins/JezzballColorblindDeuteranopia.axaml
@@ -1,0 +1,6 @@
+<Styles xmlns="https://github.com/avaloniaui">
+  <Style Selector="Window">
+    <Setter Property="Background" Value="#000000" />
+    <Setter Property="Foreground" Value="#00FFFF" />
+  </Style>
+</Styles>

--- a/Cycloside/Skins/JezzballColorblindProtanopia.axaml
+++ b/Cycloside/Skins/JezzballColorblindProtanopia.axaml
@@ -1,0 +1,6 @@
+<Styles xmlns="https://github.com/avaloniaui">
+  <Style Selector="Window">
+    <Setter Property="Background" Value="#000000" />
+    <Setter Property="Foreground" Value="#FFD700" />
+  </Style>
+</Styles>

--- a/Cycloside/Skins/JezzballColorblindTritanopia.axaml
+++ b/Cycloside/Skins/JezzballColorblindTritanopia.axaml
@@ -1,0 +1,6 @@
+<Styles xmlns="https://github.com/avaloniaui">
+  <Style Selector="Window">
+    <Setter Property="Background" Value="#000000" />
+    <Setter Property="Foreground" Value="#FF00FF" />
+  </Style>
+</Styles>


### PR DESCRIPTION
## Summary
- allow storing per-plugin game themes and skins in settings
- add theme loader and menu in Jezzball plugin
- support selecting a skin for Jezzball window
- add colorblind friendly skins

## Testing
- `dotnet build Cycloside/Cycloside.csproj -p:BuildProjectReferences=false` *(fails: AVLN2002 Duplicate x:Class)*

------
https://chatgpt.com/codex/tasks/task_e_6865c6635b10833292d01e6ed234f030