### PR TITLE
Fix ModPlugSharp namespace

### DIFF
--- a/LibModPlugSharp/ModPlugSharp.cs
+++ b/LibModPlugSharp/ModPlugSharp.cs
@@ -2,7 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace LibModPlugSharp
+namespace OpenMpt.Sharp
 {
     public class ModPlugModule : IDisposable
     {
@@ -25,7 +25,7 @@ namespace LibModPlugSharp
 
         public int Read(float[] buffer, int sampleRate)
         {
-            return NativeMethods.openmpt_module_read_interleaved_stereo(_handle, sampleRate, (UIntPtr)(buffer.Length / 2), buffer);
+            return (int)NativeMethods.openmpt_module_read_interleaved_float_stereo(_handle, sampleRate, (UIntPtr)(buffer.Length / 2), buffer);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- align `ModPlugSharp` with the library namespace
- call the correct `openmpt_module_read_interleaved_float_stereo` API

## Testing
- `dotnet build LibModPlugSharp/LibModPlugSharp.csproj -c Release`
- `dotnet build Cycloside/Cycloside.csproj -c Release` *(fails: Duplicate x:Class directive in App.axaml)*

------
https://chatgpt.com/codex/tasks/task_e_6865c9a5ca648332830f182332cb36e2