### PR TITLE
Update Cycloside docs

### DIFF
--- a/Cycloside/docs/plugin-lifecycle.md
+++ b/Cycloside/docs/plugin-lifecycle.md
@@ -16,6 +16,8 @@ public interface IPluginExtended : IPlugin
 
 The plugin manager catches exceptions thrown during `Start` and `Stop` when isolation mode is enabled. Crashes are logged if crash logging is turned on. Plugins exposing a widget should return an implementation via the `Widget` property.
 
+When **Plugin Isolation** is enabled in the Control Panel each plugin loads in its own context. This allows hot reloading without file locks and lets Cycloside unload crashing plugins cleanly.
+
 ## Plugin Bus
 
 Plugins communicate by publishing messages to the global `PluginBus` and subscribing to topics of interest:
@@ -36,4 +38,5 @@ Example:
 
 ```bash
 curl -X POST -H "X-Api-Token: <token>" http://localhost:4123/trigger -d "my:event"
+```
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scriptin
 | `LogViewerPlugin` | Tails a log file and filters lines on the fly. |
 | `MP3PlayerPlugin` | Basic audio player built on NAudio. |
 | `MacroPlugin` | Records keyboard macros and saves them to disk. Playback is Windows-only. |
+| `ModTrackerPlugin` | Plays and inspects tracker module files (MOD, IT, XM, etc.). |
 | `ProcessMonitorPlugin` | Lists running processes with CPU and memory usage. |
 | `QBasicRetroIDEPlugin` | Minimal IDE for creating QBasic-style programs. Includes an option to launch QB64 for editing. |
+| `ScreenSaverPlugin` | Runs full-screen screensavers after a period of inactivity. |
 | `TaskSchedulerPlugin` | Schedules tasks with cron-style expressions. |
 | `TextEditorPlugin` | Notepad-like editor supporting multiple files. |
+| `TerminalPlugin` | Run shell commands in a simple console window. |
 | `WallpaperPlugin` | Changes the desktop wallpaper periodically. |
 | `WidgetHostPlugin` | Hosts small widgets inside dockable panels. |
 | `WinampVisHostPlugin` | Runs Winamp AVS visualisation presets. |

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -52,6 +52,10 @@ When the plugin folder contents change, `PluginManager` reloads all plugins and
 triggers the `PluginsReloaded` event.  Subscribe to this event if your code
 needs to refresh UI elements after new plugins are detected.
 
+Isolation mode runs each plugin in a separate `AssemblyLoadContext`. Enable it
+from the Control Panel to prevent locked DLL files during hot reloads and to
+contain crashes.
+
 You can generate a boilerplate plugin with:
 ```bash
  dotnet run -- --newplugin MyPlugin
@@ -80,7 +84,8 @@ PluginBus.Publish("my:event", payload);
 
 The optional `RemoteApiServer` publishes bus events over HTTP. POST a topic name
 to `http://localhost:4123/trigger` with `X-Api-Token` or a `token` query
-parameter. See `docs/plugin-lifecycle.md` for details.
+parameter. The shared token is stored in `settings.json` under
+`RemoteApiToken`. See `docs/plugin-lifecycle.md` for details.
 
 ## Marketplace
 


### PR DESCRIPTION
## Summary
- document newly added built-in plugins
- describe plugin isolation mode and API token location
- clarify plugin lifecycle details

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68667b9744b883329cf49c2f7b949398