### PR TITLE
Fix build errors in Jezzball and QBasic plugins

### DIFF
--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -210,7 +210,7 @@ namespace Cycloside.Plugins.BuiltIn
         private static PathGeometry CreatePath(params Point[] points)
         {
             var figure = new PathFigure { StartPoint = points[0], IsClosed = true };
-            figure.Segments.Add(new PolyLineSegment(points.Skip(1), true));
+            figure.Segments.Add(new PolyLineSegment(points.Skip(1)) { IsStroked = true });
             return new PathGeometry { Figures = { figure } };
         }
     }
@@ -546,8 +546,13 @@ namespace Cycloside.Plugins.BuiltIn
         {
             foreach (var ball in _balls.ToList())
             {
-                var area = _activeAreas.FirstOrDefault(r => r.Intersects(ball.BoundingBox))
-                    ?? _activeAreas.OrderBy(a => Math.Abs(a.Center.X - ball.Position.X) + Math.Abs(a.Center.Y - ball.Position.Y)).FirstOrDefault();
+                var area = _activeAreas.FirstOrDefault(r => r.Intersects(ball.BoundingBox));
+                if (area == default)
+                {
+                    area = _activeAreas
+                        .OrderBy(a => Math.Abs(a.Center.X - ball.Position.X) + Math.Abs(a.Center.Y - ball.Position.Y))
+                        .FirstOrDefault();
+                }
 
                 if (area != default) ball.Update(area, dt);
             }

--- a/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
@@ -355,7 +355,7 @@ NEXT i
                 new Separator(),
                 examplesMenu,
                 new Separator(),
-                new MenuItem { Header = "E_xit", Command = new RelayCommand(() => _window?.Close()) }
+                new MenuItem { Header = "E_xit", Command = new Cycloside.Services.RelayCommand(() => _window?.Close()) }
             };
 
             var runItems = new object[]
@@ -371,7 +371,7 @@ NEXT i
             var toolsItems = new object[]
             {
                 new MenuItem { Header = "_Command Palette...", InputGesture = new KeyGesture(Key.P, KeyModifiers.Control | KeyModifiers.Shift), Command = OpenCommandPaletteCommand },
-                new MenuItem { Header = "_Settings...", Command = new RelayCommand(OpenSettings) },
+                new MenuItem { Header = "_Settings...", Command = new Cycloside.Services.RelayCommand(OpenSettings) },
             };
             
             return new Menu


### PR DESCRIPTION
## Summary
- fix PolyLineSegment usage and area selection logic in JezzballPlugin
- disambiguate RelayCommand type in QBasicRetroIDEPlugin
- ensure project builds with .NET 8

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v:m`

------
https://chatgpt.com/codex/tasks/task_e_6868645e89ac8332a1e1c5e512833332