### PR TITLE
Update docs for Remote API

### DIFF
--- a/Cycloside/README.md
+++ b/Cycloside/README.md
@@ -61,6 +61,16 @@ also POST events to `http://localhost:4123/trigger` to control plugins from
 other tools or scripts. Include your pre‑shared token via the `X-Api-Token`
 header or `?token=` query string or the request will be rejected with a 401.
 
+### Enabling the Remote API
+
+`RemoteApiServer` starts automatically when Cycloside runs. Set your token in
+`settings.json` under `RemoteApiToken` to secure the endpoint. Then you can send
+events over HTTP:
+
+```bash
+curl -X POST -H "X-Api-Token: <token>" http://localhost:4123/trigger -d "my:event"
+```
+
 ## ⌨️ Global Hotkeys
 
 Cycloside registers system-wide shortcuts using Avalonia's hotkey framework.


### PR DESCRIPTION
## Summary
- document how to enable Cycloside's Remote API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68748453456c8332b3bb4cf9ce4cd8bd