### PR TITLE
Conditionally enable net8.0-windows build

### DIFF
--- a/Cycloside/Cycloside.csproj
+++ b/Cycloside/Cycloside.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows'">
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>


### PR DESCRIPTION
## Summary
- limit default `TargetFrameworks` to `net8.0`
- enable the `net8.0-windows` target and Windows Forms only when `$(OS)` equals `Windows_NT`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68748448168c83328a9cddebdabf5049