### PR TITLE
Replace console write with logger call

### DIFF
--- a/Cycloside/VolatileRunnerWindow.axaml.cs
+++ b/Cycloside/VolatileRunnerWindow.axaml.cs
@@ -44,7 +44,7 @@ public partial class VolatileRunnerWindow : Window
         //    This prevents the app from crashing.
         if (langBox == null || codeBox == null)
         {
-            Console.WriteLine("Error: UI controls 'LangBox' or 'CodeBox' could not be found.");
+            Logger.Log("Error: UI controls 'LangBox' or 'CodeBox' could not be found.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- log missing control errors in `VolatileRunnerWindow`

## Testing
- `dotnet build Cycloside/Cycloside.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_68748e744aac83328dc2f165ac3d7e66