### PR TITLE
Enable hot reloading of built‑in plugins

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -148,30 +148,31 @@ public partial class App : Application
 
     private void LoadAllPlugins(PluginManager manager, AppSettings settings)
     {
-        void TryAdd(IPlugin plugin)
+        void TryAdd(Func<IPlugin> factory)
         {
+            var plugin = factory();
             if (!settings.DisableBuiltInPlugins || settings.SafeBuiltInPlugins.GetValueOrDefault(plugin.Name, false))
-                manager.AddPlugin(plugin);
+                manager.AddBuiltInPlugin(factory);
         }
 
-        TryAdd(new DateTimeOverlayPlugin());
-        TryAdd(new MP3PlayerPlugin());
-        TryAdd(new MacroPlugin());
-        TryAdd(new TextEditorPlugin());
-        TryAdd(new WallpaperPlugin());
-        TryAdd(new ClipboardManagerPlugin());
-        TryAdd(new FileWatcherPlugin());
-        TryAdd(new ProcessMonitorPlugin());
-        TryAdd(new TaskSchedulerPlugin());
-        TryAdd(new DiskUsagePlugin());
-        TryAdd(new TerminalPlugin());
-        TryAdd(new LogViewerPlugin());
-        TryAdd(new EnvironmentEditorPlugin());
-        TryAdd(new JezzballPlugin());
-        TryAdd(new WidgetHostPlugin(manager));
-        TryAdd(new WinampVisHostPlugin());
-        TryAdd(new QBasicRetroIDEPlugin());
-        TryAdd(new ScreenSaverPlugin());
+        TryAdd(() => new DateTimeOverlayPlugin());
+        TryAdd(() => new MP3PlayerPlugin());
+        TryAdd(() => new MacroPlugin());
+        TryAdd(() => new TextEditorPlugin());
+        TryAdd(() => new WallpaperPlugin());
+        TryAdd(() => new ClipboardManagerPlugin());
+        TryAdd(() => new FileWatcherPlugin());
+        TryAdd(() => new ProcessMonitorPlugin());
+        TryAdd(() => new TaskSchedulerPlugin());
+        TryAdd(() => new DiskUsagePlugin());
+        TryAdd(() => new TerminalPlugin());
+        TryAdd(() => new LogViewerPlugin());
+        TryAdd(() => new EnvironmentEditorPlugin());
+        TryAdd(() => new JezzballPlugin());
+        TryAdd(() => new WidgetHostPlugin(manager));
+        TryAdd(() => new WinampVisHostPlugin());
+        TryAdd(() => new QBasicRetroIDEPlugin());
+        TryAdd(() => new ScreenSaverPlugin());
     }
 
     private void RegisterHotkeys(PluginManager manager)


### PR DESCRIPTION
## Summary
- ensure built‑in plugins are recreated during reload
- store factories for built‑in plugins and re-add them on reload
- update `App` to register built‑ins via factories
- trigger plugin reload event once

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874817f471c83329234e8e679d53421