### PR TITLE
Fix build errors in Cycloside

### DIFF
--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -130,7 +130,8 @@ namespace Cycloside.Plugins.BuiltIn
         {
             var dir = Path.Combine(AppContext.BaseDirectory, "Skins");
             return Directory.Exists(dir)
-                ? Directory.GetFiles(dir, "*.axaml").Select(Path.GetFileNameWithoutExtension)
+                ? Directory.GetFiles(dir, "*.axaml")
+                    .Select(f => Path.GetFileNameWithoutExtension(f)!)
                 : Array.Empty<string>();
         }
     }
@@ -209,9 +210,18 @@ namespace Cycloside.Plugins.BuiltIn
 
         private static PathGeometry CreatePath(params Point[] points)
         {
-            var figure = new PathFigure { StartPoint = points[0], IsClosed = true };
+            var figure = new PathFigure
+            {
+                StartPoint = points[0],
+                IsClosed = true,
+                Segments = new PathSegments()
+            };
             figure.Segments.Add(new PolyLineSegment(points.Skip(1)) { IsStroked = true });
-            return new PathGeometry { Figures = { figure } };
+
+            var geometry = new PathGeometry();
+            geometry.Figures ??= new PathFigures();
+            geometry.Figures.Add(figure);
+            return geometry;
         }
     }
 

--- a/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QBasicRetroIDEPlugin.cs
@@ -32,7 +32,7 @@ namespace Cycloside.Plugins.BuiltIn
         private string _qb64Path = "qb64pe"; // Updated default
         private Process? _qb64Process;
         private string? _currentFile;
-        private string? _projectPath;
+        private string? _projectPath = string.Empty;
         private bool _isCompiling = false;
         private bool _hasUnsavedChanges = false;
         

--- a/Cycloside/ThemeSettingsWindow.axaml.cs
+++ b/Cycloside/ThemeSettingsWindow.axaml.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using Cycloside.Plugins;
 using Cycloside.Services;
-using Avalonia.Media;
 using Avalonia.Layout;
 
 namespace Cycloside;


### PR DESCRIPTION
## Summary
- remove duplicate `Avalonia.Media` import
- fix nullability issues in Jezzball plugin
- ensure path geometry segments initialized
- default `_projectPath` in QBasicRetroIDEPlugin
- confirm build using .NET 8.0

## Testing
- `dotnet build Cycloside/Cycloside.csproj -warnaserror`
- `dotnet --version`


------
https://chatgpt.com/codex/tasks/task_e_687540b5d8048332bfbe0a2148425a79