### PR TITLE
Introduce notification center

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -65,7 +65,7 @@ public partial class App : Application
     
     private MainWindow CreateMainWindow(AppSettings settings)
     {
-        _pluginManager = new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), msg => Logger.Log(msg));
+        _pluginManager = new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), Services.NotificationCenter.Notify);
         
         // Subscribe to plugin reloads to update the UI when plugins are refreshed.
         _pluginManager.PluginsReloaded += OnPluginsReloaded;
@@ -84,23 +84,49 @@ public partial class App : Application
         viewModel.ExitCommand = new RelayCommand(() => Shutdown());
         
         // Toggle plugin enablement from the main window.
-        viewModel.StartPluginCommand = new RelayCommand(plugin =>
+        viewModel.StartPluginCommand = new RelayCommand(pluginObj =>
         {
-            if (plugin is not IPlugin p || _pluginManager is null) return;
-            
-            bool shouldBeEnabled = !_pluginManager.IsEnabled(p);
-            if (shouldBeEnabled)
+            if (pluginObj is not IPlugin plugin || _pluginManager is null) return;
+
+            if (plugin is IWorkspaceItem workspace)
             {
-                _pluginManager.EnablePlugin(p);
+                var existing = viewModel.WorkspaceItems.FirstOrDefault(w => w.Plugin == plugin);
+                bool enable = existing is null;
+                if (enable)
+                {
+                    workspace.UseWorkspace = true;
+                    _pluginManager.EnablePlugin(plugin);
+                    var view = workspace.BuildWorkspaceView();
+                    var vm = new WorkspaceItemViewModel(plugin.Name, view, plugin);
+                    viewModel.WorkspaceItems.Add(vm);
+                    viewModel.SelectedWorkspaceItem = vm;
+                }
+                else
+                {
+                    workspace.UseWorkspace = false;
+                    _pluginManager.DisablePlugin(plugin);
+                    viewModel.WorkspaceItems.Remove(existing!);
+                }
+                SettingsManager.Settings.PluginEnabled[plugin.Name] = enable;
+                SettingsManager.Save();
+                WorkspaceProfiles.UpdatePlugin(settings.ActiveProfile, plugin.Name, enable);
             }
             else
             {
-                _pluginManager.DisablePlugin(p);
-            }
+                bool shouldBeEnabled = !_pluginManager.IsEnabled(plugin);
+                if (shouldBeEnabled)
+                {
+                    _pluginManager.EnablePlugin(plugin);
+                }
+                else
+                {
+                    _pluginManager.DisablePlugin(plugin);
+                }
 
-            SettingsManager.Settings.PluginEnabled[p.Name] = shouldBeEnabled;
-            SettingsManager.Save();
-            WorkspaceProfiles.UpdatePlugin(settings.ActiveProfile, p.Name, shouldBeEnabled);
+                SettingsManager.Settings.PluginEnabled[plugin.Name] = shouldBeEnabled;
+                SettingsManager.Save();
+                WorkspaceProfiles.UpdatePlugin(settings.ActiveProfile, plugin.Name, shouldBeEnabled);
+            }
         });
 
         _remoteServer = new RemoteApiServer(_pluginManager, settings.RemoteApiToken);
@@ -167,6 +193,7 @@ public partial class App : Application
         TryAdd(() => new DiskUsagePlugin());
         TryAdd(() => new TerminalPlugin());
         TryAdd(() => new LogViewerPlugin());
+        TryAdd(() => new NotificationCenterPlugin());
         TryAdd(() => new EnvironmentEditorPlugin());
         TryAdd(() => new JezzballPlugin());
         TryAdd(() => new WidgetHostPlugin(manager));

--- a/Cycloside/ControlPanelWindow.axaml.cs
+++ b/Cycloside/ControlPanelWindow.axaml.cs
@@ -18,7 +18,7 @@ public partial class ControlPanelWindow : Window
         WindowEffectsManager.Instance.ApplyConfiguredEffects(this, nameof(ControlPanelWindow));
     }
 
-    public ControlPanelWindow() : this(new PluginManager(System.IO.Path.Combine(AppContext.BaseDirectory, "Plugins"), _ => { }))
+    public ControlPanelWindow() : this(new PluginManager(System.IO.Path.Combine(AppContext.BaseDirectory, "Plugins"), Services.NotificationCenter.Notify))
     {
     }
 

--- a/Cycloside/MainWindow.axaml
+++ b/Cycloside/MainWindow.axaml
@@ -53,14 +53,29 @@
           Plugins like the Widget Host will add their UI elements here.
           The background is a subtle radial gradient for visual appeal.
         -->
-        <Canvas Name="DesktopCanvas">
-            <Canvas.Background>
-                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="70%" RadiusY="70%">
-                    <GradientStop Color="{DynamicResource ThemeAccentColor4}" Offset="0" />
-                    <GradientStop Color="{DynamicResource ThemeBackgroundColor}" Offset="1" />
-                </RadialGradientBrush>
-            </Canvas.Background>
-        </Canvas>
+        <Grid>
+            <Canvas Name="DesktopCanvas">
+                <Canvas.Background>
+                    <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="70%" RadiusY="70%">
+                        <GradientStop Color="{DynamicResource ThemeAccentColor4}" Offset="0" />
+                        <GradientStop Color="{DynamicResource ThemeBackgroundColor}" Offset="1" />
+                    </RadialGradientBrush>
+                </Canvas.Background>
+            </Canvas>
+            <TabControl ItemsSource="{Binding WorkspaceItems}"
+                        SelectedItem="{Binding SelectedWorkspaceItem, Mode=TwoWay}">
+                <TabControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:WorkspaceItemViewModel">
+                        <TextBlock Text="{Binding Header}" Margin="5,2"/>
+                    </DataTemplate>
+                </TabControl.ItemTemplate>
+                <TabControl.ContentTemplate>
+                    <DataTemplate x:DataType="vm:WorkspaceItemViewModel">
+                        <ContentControl Content="{Binding View}" />
+                    </DataTemplate>
+                </TabControl.ContentTemplate>
+            </TabControl>
+        </Grid>
 
     </DockPanel>
 </Window>

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
@@ -100,7 +101,7 @@ namespace Cycloside.Plugins.BuiltIn
     /// <summary>
     /// The final, optimized MP3 Player plugin acting as a ViewModel.
     /// </summary>
-    public partial class MP3PlayerPlugin : ObservableObject, IPlugin, IDisposable
+    public partial class MP3PlayerPlugin : ObservableObject, IPlugin, IDisposable, IWorkspaceItem
     {
         private const string AudioDataTopic = "audio:data";
 
@@ -119,6 +120,7 @@ namespace Cycloside.Plugins.BuiltIn
         public Version Version => new(1, 7, 0);
         public Widgets.IWidget? Widget => new Widgets.BuiltIn.Mp3Widget(this);
         public bool ForceDefaultTheme => false;
+        public bool UseWorkspace { get; set; }
 
         // --- Observable Properties ---
         public ObservableCollection<string> Playlist { get; } = new();
@@ -139,16 +141,27 @@ namespace Cycloside.Plugins.BuiltIn
         // --- Plugin Lifecycle & Disposal ---
         public void Start()
         {
+            if (UseWorkspace)
+            {
+                // When hosted in the workspace we don't create a window.
+                return;
+            }
+
             if (_window != null)
             {
                 _window.Activate();
                 return;
             }
-            
+
             _window = new Views.MP3PlayerWindow { DataContext = this };
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
             _window.Closed += (_, _) => _window = null;
             _window.Show();
+        }
+
+        public Control BuildWorkspaceView()
+        {
+            return new Views.MP3PlayerView { DataContext = this };
         }
 
         public void Stop() => Dispose();

--- a/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Cycloside.Services;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+/// <summary>
+/// Displays recent notifications from <see cref="NotificationCenter"/>.
+/// </summary>
+public class NotificationCenterPlugin : IPlugin, IDisposable, IWorkspaceItem
+{
+    private Views.NotificationCenterWindow? _window;
+
+    public ObservableCollection<string> Messages { get; } = new();
+    public string Name => "Notification Center";
+    public string Description => "View recent notifications";
+    public Version Version => new(0,1,0);
+    public Widgets.IWidget? Widget => null;
+    public bool ForceDefaultTheme => false;
+    public bool UseWorkspace { get; set; }
+
+    public void Start()
+    {
+        NotificationCenter.NotificationReceived += OnNotification;
+        if (UseWorkspace) return;
+        ShowWindow();
+    }
+
+    private void ShowWindow()
+    {
+        if (_window != null)
+        {
+            _window.Activate();
+            return;
+        }
+        _window = new Views.NotificationCenterWindow { DataContext = this };
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
+        _window.Closed += (_, _) => _window = null;
+        _window.Show();
+    }
+
+    public Control BuildWorkspaceView() => new Views.NotificationCenterView { DataContext = this };
+
+    private void OnNotification(string msg)
+    {
+        Dispatcher.UIThread.Post(() => Messages.Add(msg));
+    }
+
+    public void Stop() => Dispose();
+
+    public void Dispose()
+    {
+        NotificationCenter.NotificationReceived -= OnNotification;
+        _window?.Close();
+        _window = null;
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/Views/MP3PlayerView.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/MP3PlayerView.axaml
@@ -1,0 +1,68 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:Cycloside.Plugins.BuiltIn"
+        xmlns:view="clr-namespace:Cycloside.Plugins.BuiltIn.Views"
+        x:Class="Cycloside.Plugins.BuiltIn.Views.MP3PlayerView"
+        x:DataType="local:MP3PlayerPlugin">
+    <Design.DataContext>
+        <local:MP3PlayerPlugin/>
+    </Design.DataContext>
+
+    <Border Padding="10" Background="{DynamicResource ThemeBackgroundBrush}">
+        <DockPanel LastChildFill="True">
+
+            <TextBlock Text="{Binding ErrorMessage}"
+                       Foreground="Red"
+                       IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                       DockPanel.Dock="Top"
+                       Margin="0,0,0,5"
+                       TextWrapping="Wrap"/>
+
+            <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto">
+                <TextBlock Text="{Binding CurrentTrackName}"
+                           Grid.Column="0"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis"/>
+                <Button Content="Add Files..."
+                        Grid.Column="1"
+                        Command="{Binding AddFilesCommand}"/>
+            </Grid>
+
+            <DockPanel DockPanel.Dock="Top" Margin="0,8">
+                <TextBlock Text="{Binding CurrentTime, StringFormat=mm\\:ss}" DockPanel.Dock="Left" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding TotalTime, StringFormat=mm\\:ss}" DockPanel.Dock="Right" VerticalAlignment="Center"/>
+                <Slider Value="{Binding CurrentTime.TotalSeconds}"
+                        Maximum="{Binding TotalTime.TotalSeconds}"
+                        PointerReleased="SeekSlider_OnPointerReleased"
+                        Margin="8,0"/>
+            </DockPanel>
+
+            <StackPanel Orientation="Horizontal" Spacing="5"
+                        HorizontalAlignment="Center"
+                        DockPanel.Dock="Top" Margin="0,5,0,10">
+                <Button Content="&#x25C0;&#x25C0;" Command="{Binding PreviousCommand}"/>
+                <Button Content="&#x25B6;" Command="{Binding PlayCommand}"/>
+                <Button Content="&#x23F8;" Command="{Binding PauseCommand}"/>
+                <Button Content="&#x25A0;" Command="{Binding StopPlaybackCommand}"/>
+                <Button Content="&#x25B6;&#x25B6;" Command="{Binding NextCommand}"/>
+            </StackPanel>
+
+            <DockPanel DockPanel.Dock="Top">
+                <Button Content="&#x1F507;" Command="{Binding ToggleMuteCommand}" DockPanel.Dock="Left"/>
+                <Slider Value="{Binding Volume, Mode=TwoWay}" Minimum="0" Maximum="1.0" Margin="8,0"/>
+            </DockPanel>
+
+            <ListBox ItemsSource="{Binding Playlist}"
+                     Margin="0,10,0,0"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding ., Converter={x:Static view:FullPathToFileNameConverter.Instance}}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/Cycloside/Plugins/BuiltIn/Views/MP3PlayerView.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/MP3PlayerView.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using System.IO;
+
+// Chose the more modern file-scoped namespace syntax.
+namespace Cycloside.Plugins.BuiltIn.Views;
+
+public partial class MP3PlayerView : UserControl
+{
+    public MP3PlayerView()
+    {
+        InitializeComponent();
+    }
+
+    private void SeekSlider_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (DataContext is MP3PlayerPlugin vm && sender is Slider slider)
+        {
+            var seekTime = TimeSpan.FromSeconds(slider.Value);
+            if (vm.SeekCommand.CanExecute(seekTime))
+            {
+                vm.SeekCommand.Execute(seekTime);
+            }
+        }
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/Views/NotificationCenterView.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/NotificationCenterView.axaml
@@ -1,0 +1,12 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Cycloside.Plugins.BuiltIn.Views.NotificationCenterView"
+             x:DataType="local:NotificationCenterPlugin"
+             xmlns:local="clr-namespace:Cycloside.Plugins.BuiltIn">
+    <Design.DataContext>
+        <local:NotificationCenterPlugin/>
+    </Design.DataContext>
+    <Border Padding="10" Background="{DynamicResource ThemeBackgroundBrush}">
+        <ListBox ItemsSource="{Binding Messages}"/>
+    </Border>
+</UserControl>

--- a/Cycloside/Plugins/BuiltIn/Views/NotificationCenterView.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/NotificationCenterView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Cycloside.Plugins.BuiltIn.Views;
+
+public partial class NotificationCenterView : UserControl
+{
+    public NotificationCenterView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/Views/NotificationCenterWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/NotificationCenterWindow.axaml
@@ -1,0 +1,9 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:Cycloside.Plugins.BuiltIn.Views"
+        x:Class="Cycloside.Plugins.BuiltIn.Views.NotificationCenterWindow"
+        x:DataType="local:NotificationCenterPlugin"
+        xmlns:local="clr-namespace:Cycloside.Plugins.BuiltIn"
+        Title="Notifications" Width="400" Height="300">
+    <view:NotificationCenterView />
+</Window>

--- a/Cycloside/Plugins/BuiltIn/Views/NotificationCenterWindow.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/NotificationCenterWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Cycloside.Plugins.BuiltIn.Views;
+
+public partial class NotificationCenterWindow : Window
+{
+    public NotificationCenterWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Cycloside/RuntimeSettingsWindow.axaml.cs
+++ b/Cycloside/RuntimeSettingsWindow.axaml.cs
@@ -38,7 +38,7 @@ public partial class RuntimeSettingsWindow : Window
     }
 
     // Parameterless constructor for designer support
-    public RuntimeSettingsWindow() : this(new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), _ => Logger.Log("Designer")))
+    public RuntimeSettingsWindow() : this(new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), Services.NotificationCenter.Notify))
     {
     }
 

--- a/Cycloside/SDK/IWorkspaceItem.cs
+++ b/Cycloside/SDK/IWorkspaceItem.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+
+namespace Cycloside.Plugins;
+
+/// <summary>
+/// Optional interface for plugins that can render their UI inside the
+/// unified workspace. Implementing plugins should return a control that
+/// represents their main view when docked or tabbed.
+/// </summary>
+public interface IWorkspaceItem
+{
+    /// <summary>
+    /// Builds the view used when the plugin is hosted in the workspace.
+    /// </summary>
+    Control BuildWorkspaceView();
+
+    /// <summary>
+    /// Set by the host when the plugin is opened inside the workspace so
+    /// the plugin can avoid showing its own window.
+    /// </summary>
+    bool UseWorkspace { get; set; }
+}

--- a/Cycloside/Services/NotificationCenter.cs
+++ b/Cycloside/Services/NotificationCenter.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Cycloside.Services;
+
+/// <summary>
+/// Provides a simple pub/sub mechanism for user notifications.
+/// Any component can call <see cref="Notify"/> to broadcast a message
+/// which listeners like the Notification Center plugin can display.
+/// </summary>
+public static class NotificationCenter
+{
+    /// <summary>
+    /// Raised whenever a new notification message arrives.
+    /// </summary>
+    public static event Action<string>? NotificationReceived;
+
+    /// <summary>
+    /// Broadcasts a message to all subscribers and logs it.
+    /// </summary>
+    public static void Notify(string message)
+    {
+        NotificationReceived?.Invoke(message);
+        Logger.Log(message);
+    }
+}

--- a/Cycloside/ThemeSettingsWindow.axaml.cs
+++ b/Cycloside/ThemeSettingsWindow.axaml.cs
@@ -22,7 +22,7 @@ public partial class ThemeSettingsWindow : Window
 
     // FIX: Add a parameterless constructor for XAML designer support.
     // This resolves the AVLN3001 build warning.
-    public ThemeSettingsWindow() : this(new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), _ => {}))
+    public ThemeSettingsWindow() : this(new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), Services.NotificationCenter.Notify))
     {
         // This constructor is used by the Avalonia designer and XAML loader.
         // It calls the main constructor with a temporary PluginManager instance.

--- a/Cycloside/ViewModels/MainWindowViewModel.cs
+++ b/Cycloside/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,10 @@ namespace Cycloside.ViewModels
     {
         public ObservableCollection<IPlugin> AvailablePlugins { get; }
 
+        public ObservableCollection<WorkspaceItemViewModel> WorkspaceItems { get; } = new();
+        [ObservableProperty]
+        private WorkspaceItemViewModel? _selectedWorkspaceItem;
+
         public ICommand? ExitCommand { get; set; }
         public ICommand? StartPluginCommand { get; set; }
 

--- a/Cycloside/ViewModels/WorkspaceItemViewModel.cs
+++ b/Cycloside/ViewModels/WorkspaceItemViewModel.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+
+namespace Cycloside.ViewModels;
+
+/// <summary>
+/// Represents an item hosted in the unified workspace.
+/// </summary>
+public class WorkspaceItemViewModel
+{
+    public WorkspaceItemViewModel(string header, Control view, Plugins.IPlugin plugin)
+    {
+        Header = header;
+        View = view;
+        Plugin = plugin;
+    }
+
+    public string Header { get; }
+    public Control View { get; }
+    public Plugins.IPlugin Plugin { get; }
+}


### PR DESCRIPTION
## Summary
- create `NotificationCenter` service for pub/sub messages
- implement `NotificationCenterPlugin` with a simple window and workspace view
- register plugin in the app and use notification service for plugin manager
- update design-time window constructors
- fix bindings on workspace tab control

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687543d1c1ac8332b6a71c5319006224