### PR TITLE
Add copy/delete actions to Clipboard Manager

### DIFF
--- a/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/ClipboardManagerWindow.axaml
@@ -8,18 +8,25 @@
         Title="Clipboard History"
         Width="300"
         Height="450">
-  
-  <ListBox x:Name="HistoryList"
-           ItemsSource="{Binding History}"
-           SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
-           SelectionMode="Single"
-           DoubleTapped="ListBox_DoubleTapped">
-    <ListBox.ContextMenu>
-      <ContextMenu>
-        <MenuItem Header="Copy" Command="{Binding CopySelectedCommand}"/>
-        <MenuItem Header="Delete" Command="{Binding DeleteSelectedCommand}"/>
-      </ContextMenu>
-    </ListBox.ContextMenu>
-  </ListBox>
-  
+
+  <Grid RowDefinitions="* Auto" Margin="4">
+    <ListBox x:Name="HistoryList"
+             ItemsSource="{Binding History}"
+             SelectedItem="{Binding SelectedEntry, Mode=TwoWay}"
+             SelectionMode="Single"
+             DoubleTapped="ListBox_DoubleTapped">
+      <ListBox.ContextMenu>
+        <ContextMenu>
+          <MenuItem Header="Copy" Command="{Binding CopySelectedCommand}"/>
+          <MenuItem Header="Delete" Command="{Binding DeleteSelectedCommand}"/>
+        </ContextMenu>
+      </ListBox.ContextMenu>
+    </ListBox>
+
+    <StackPanel Orientation="Horizontal" Spacing="4" Grid.Row="1" HorizontalAlignment="Right" Margin="0,4,0,0">
+      <Button Content="Copy" Command="{Binding CopySelectedCommand}" Width="80"/>
+      <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Width="80"/>
+    </StackPanel>
+  </Grid>
+
 </Window>


### PR DESCRIPTION
## Summary
- enhance ClipboardManagerWindow with Copy/Delete buttons
- verify RelayCommands exist for Copy and Delete operations

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo` *(fails: 'RelayCommand' ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_68759ee2eac483329fd526921c0129a6