### PR TITLE
Fix JezzballPlugin warnings

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -18,7 +18,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.Input;
 
 namespace Cycloside;
 

--- a/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
@@ -76,12 +76,15 @@ namespace Cycloside.Plugins.BuiltIn
                 {
                     // Build a simple model on a background thread to avoid creating
                     // UI elements off the UI thread.
+                    // Build the plain directory model on a background thread.
                     var rootModel = await Task.Run(() => BuildDirectoryModel(new DirectoryInfo(path)));
 
-                    // Once done, create TreeViewItems on the UI thread from the model.
+                    // Convert the model to UI elements on the UI thread to avoid
+                    // cross-thread exceptions when constructing TreeViewItem instances.
                     await Dispatcher.UIThread.InvokeAsync(() =>
                     {
-                        _tree.ItemsSource = new[] { ConvertToTreeViewItem(rootModel) };
+                        var rootItem = ConvertToTreeViewItem(rootModel);
+                        _tree.ItemsSource = new[] { rootItem };
                         _statusText.Text = $"Analysis complete for '{path}'.";
                     });
                 }

--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -130,7 +130,8 @@ namespace Cycloside.Plugins.BuiltIn
         {
             var dir = Path.Combine(AppContext.BaseDirectory, "Skins");
             return Directory.Exists(dir)
-                ? Directory.GetFiles(dir, "*.axaml").Select(Path.GetFileNameWithoutExtension)
+                ? Directory.GetFiles(dir, "*.axaml")
+                    .Select(f => Path.GetFileNameWithoutExtension(f) ?? string.Empty)
                 : Array.Empty<string>();
         }
     }
@@ -209,9 +210,19 @@ namespace Cycloside.Plugins.BuiltIn
 
         private static PathGeometry CreatePath(params Point[] points)
         {
-            var figure = new PathFigure { StartPoint = points[0], IsClosed = true };
-            figure.Segments.Add(new PolyLineSegment(points.Skip(1)) { IsStroked = true });
-            return new PathGeometry { Figures = { figure } };
+            var figure = new PathFigure
+            {
+                StartPoint = points[0],
+                IsClosed = true,
+                Segments = new PathSegments()
+            };
+
+            figure.Segments!.Add(new PolyLineSegment(points.Skip(1)) { IsStroked = true });
+
+            return new PathGeometry
+            {
+                Figures = new PathFigures { figure }
+            };
         }
     }
 


### PR DESCRIPTION
## Summary
- guard nullability in `GetSkinNames`
- initialize path collections for FlowerBox shapes

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_68759f04db9083328232b1b66f115c82