### PR TITLE
Fix restore path in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore Cycloside/Cycloside.csproj
+
+      - name: Build
+        run: dotnet build Cycloside/Cycloside.csproj --configuration Release --no-restore
+
+      - name: Test
+        if: ${{ hashFiles('**/*Tests.csproj') != '' }}
+        run: dotnet test --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -100,3 +100,8 @@ Ensure the .NET 8 SDK is installed (download from https://dotnet.microsoft.com/d
 
 ```bash
 dotnet build Cycloside/Cycloside.csproj
+```
+
+GitHub Actions automatically build the project using
+[`dotnet.yml`](.github/workflows/dotnet.yml). Unit tests will run when they are
+added.


### PR DESCRIPTION
## Summary
- correct `dotnet restore` path so GitHub Actions finds the project

## Testing
- `dotnet --version`
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6875b0d621f083329bda44165eb30172