### PR TITLE
Fix restore path in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,31 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        working-directory: Cycloside
+        run: dotnet restore
+
+      - name: Build
+        working-directory: Cycloside
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        if: ${{ hashFiles('**/*Tests.csproj') != '' }}
+        working-directory: Cycloside
+        run: dotnet test --no-build --verbosity normal

--- a/README.md
+++ b/README.md
@@ -100,3 +100,8 @@ Ensure the .NET 8 SDK is installed (download from https://dotnet.microsoft.com/d
 
 ```bash
 dotnet build Cycloside/Cycloside.csproj
+```
+
+GitHub Actions automatically build the project using
+[`dotnet.yml`](.github/workflows/dotnet.yml). Unit tests will run when they are
+added.


### PR DESCRIPTION
## Summary
- set working directory for `dotnet` steps so restore runs on the project

## Testing
- `dotnet --version`
- `dotnet build Cycloside/Cycloside.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6875b0d621f083329bda44165eb30172