### PR TITLE
Generalize hotkey registration

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -247,18 +247,20 @@ public partial class App : Application
             try { gesture = KeyGesture.Parse(kv.Value); }
             catch { continue; }
 
-            if (kv.Key == "WidgetHost")
+            // Look for a plugin whose name matches the hotkey key (ignoring spaces)
+            var plugin = manager.Plugins.FirstOrDefault(p =>
+                string.Equals(p.Name.Replace(" ", string.Empty), kv.Key,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (plugin != null)
             {
                 HotkeyManager.Register(gesture, () =>
                 {
-                    var plugin = manager.Plugins.FirstOrDefault(p => p.Name == "Widget Host");
-                    if (plugin != null)
-                    {
-                        if (manager.IsEnabled(plugin)) manager.DisablePlugin(plugin);
-                        else manager.EnablePlugin(plugin);
-                    }
+                    if (manager.IsEnabled(plugin)) manager.DisablePlugin(plugin);
+                    else manager.EnablePlugin(plugin);
                 });
             }
+            // Additional actions can be handled here in the future
         }
     }
 


### PR DESCRIPTION
## Summary
- let App read hotkeys from `SettingsManager.Settings.Hotkeys`
- toggle plugins when the sanitized plugin name matches a hotkey name

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6875b0d763208332912bc27bdaf78e94