### PR TITLE
Add ANSI support to TerminalPlugin

### DIFF
--- a/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/TerminalWindow.axaml
@@ -8,10 +8,8 @@
             <TextBox x:Name="InputBox" Width="600" />
             <Button x:Name="RunButton" Content="Run" />
         </StackPanel>
-        <TextBox x:Name="OutputBox"
-                 AcceptsReturn="True"
-                 IsReadOnly="True"
-                 FontFamily="monospace"
-                 Margin="5" />
+        <ScrollViewer x:Name="OutputScroll" Margin="5" VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="OutputPanel" />
+        </ScrollViewer>
     </DockPanel>
 </Window>

--- a/Cycloside/TODO.md
+++ b/Cycloside/TODO.md
@@ -29,7 +29,7 @@ This is a development checklist for your Avalonia-powered hacker’s paradise ap
 - [~] **Terminal Emulator Plugin**
     - [x] Shell command execution
     - [x] Command history (arrow keys)
-    - [ ] Styled output (color text, scrollback)
+    - [x] Styled output (color text, scrollback)
 - [ ] **Network Tools Plugin**
     - [ ] Ping, traceroute utilities
     - [ ] Port scanner


### PR DESCRIPTION
## Summary
- enhance TerminalWindow layout for colored output
- parse ANSI escape sequences in TerminalPlugin
- keep limited scrollback history
- mark TODO for styled output complete

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6875b0d87c888332a854c4bd643fa31c