### PR TITLE
Add powerups and teleporting balls to Jezzball

### DIFF
--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -140,8 +140,8 @@ namespace Cycloside.Plugins.BuiltIn
     #region Game Model (State and Logic)
 
     public enum WallOrientation { Vertical, Horizontal }
-    public enum BallType { Normal, Slow, Fast, Splitting }
-    public enum PowerUpType { IceWall }
+    public enum BallType { Normal, Slow, Fast, Splitting, Teleporting }
+    public enum PowerUpType { IceWall, ExtraLife, Freeze, DoubleScore }
 
     public class JezzballTheme
     {
@@ -153,10 +153,14 @@ namespace Cycloside.Plugins.BuiltIn
         public Pen IceWallPen { get; init; } = new Pen(Brushes.LightCyan, 5, lineCap: PenLineCap.Round);
         public Pen IcePreviewPen { get; init; } = new Pen(new SolidColorBrush(Colors.LightCyan, 0.8), 2, DashStyle.Dash);
         public IBrush PowerUpBrush { get; init; } = Brushes.Aqua;
+        public IBrush ExtraLifeBrush { get; init; } = Brushes.LimeGreen;
+        public IBrush FreezeBrush { get; init; } = Brushes.LightBlue;
+        public IBrush DoubleScoreBrush { get; init; } = Brushes.Gold;
         public IBrush BallNormalBrush { get; init; } = Brushes.Crimson;
         public IBrush BallSlowBrush { get; init; } = Brushes.DeepSkyBlue;
         public IBrush BallFastBrush { get; init; } = Brushes.OrangeRed;
         public IBrush BallSplittingBrush { get; init; } = Brushes.MediumPurple;
+        public IBrush BallTeleportBrush { get; init; } = Brushes.Gold;
     }
 
     // NEW: A static class to generate the procedural brushes for the FlowerBox theme.
@@ -240,6 +244,10 @@ namespace Cycloside.Plugins.BuiltIn
                 BallSlowBrush = FlowerBoxResources.CreateTetraBrush(),
                 BallFastBrush = FlowerBoxResources.CreatePyramidBrush(),
                 BallSplittingBrush = FlowerBoxResources.CreateCubeBrush(), // Can be another shape
+                BallTeleportBrush = Brushes.Gold,
+                ExtraLifeBrush = Brushes.LimeGreen,
+                FreezeBrush = Brushes.LightBlue,
+                DoubleScoreBrush = Brushes.Gold,
             },
             ["Classic"] = new JezzballTheme
             {
@@ -261,7 +269,11 @@ namespace Cycloside.Plugins.BuiltIn
                 BallNormalBrush = Brushes.Crimson,
                 BallSlowBrush = Brushes.DeepSkyBlue,
                 BallFastBrush = Brushes.OrangeRed,
-                BallSplittingBrush = Brushes.MediumPurple
+                BallSplittingBrush = Brushes.MediumPurple,
+                BallTeleportBrush = Brushes.Gold,
+                ExtraLifeBrush = Brushes.LimeGreen,
+                FreezeBrush = Brushes.LightBlue,
+                DoubleScoreBrush = Brushes.Gold
             },
             ["Neon"] = new JezzballTheme
             {
@@ -283,7 +295,11 @@ namespace Cycloside.Plugins.BuiltIn
                 BallNormalBrush = Brushes.HotPink,
                 BallSlowBrush = Brushes.Lime,
                 BallFastBrush = Brushes.Yellow,
-                BallSplittingBrush = Brushes.Cyan
+                BallSplittingBrush = Brushes.Cyan,
+                BallTeleportBrush = Brushes.Gold,
+                ExtraLifeBrush = Brushes.LimeGreen,
+                FreezeBrush = Brushes.LightBlue,
+                DoubleScoreBrush = Brushes.Gold
             },
             ["Pastel"] = new JezzballTheme
             {
@@ -305,7 +321,30 @@ namespace Cycloside.Plugins.BuiltIn
                 BallNormalBrush = new SolidColorBrush(Color.FromRgb(255, 105, 97)),
                 BallSlowBrush = new SolidColorBrush(Color.FromRgb(135, 206, 235)),
                 BallFastBrush = new SolidColorBrush(Color.FromRgb(255, 160, 122)),
-                BallSplittingBrush = new SolidColorBrush(Color.FromRgb(216, 191, 216))
+                BallSplittingBrush = new SolidColorBrush(Color.FromRgb(216, 191, 216)),
+                BallTeleportBrush = Brushes.Gold,
+                ExtraLifeBrush = Brushes.LimeGreen,
+                FreezeBrush = Brushes.LightBlue,
+                DoubleScoreBrush = Brushes.Gold
+            },
+            ["Retro"] = new JezzballTheme
+            {
+                BackgroundBrush = Brushes.Black,
+                WallPen = new Pen(Brushes.Gray, 3, lineCap: PenLineCap.Square),
+                PreviewPen = new Pen(Brushes.White, 1, DashStyle.Dot),
+                FilledBrush = new SolidColorBrush(Color.FromRgb(30, 30, 30), 0.6),
+                FlashBrush = new SolidColorBrush(Colors.White, 0.3),
+                IceWallPen = new Pen(Brushes.Silver, 5),
+                IcePreviewPen = new Pen(Brushes.Silver, 1, DashStyle.Dash),
+                PowerUpBrush = Brushes.Yellow,
+                BallNormalBrush = Brushes.White,
+                BallSlowBrush = Brushes.LightGray,
+                BallFastBrush = Brushes.Silver,
+                BallSplittingBrush = Brushes.Gray,
+                BallTeleportBrush = Brushes.Gold,
+                ExtraLifeBrush = Brushes.LimeGreen,
+                FreezeBrush = Brushes.LightBlue,
+                DoubleScoreBrush = Brushes.Gold
             }
         };
     }
@@ -362,6 +401,7 @@ namespace Cycloside.Plugins.BuiltIn
         public double Radius { get; }
         public IBrush Fill { get; private set; }
         public BallType Type { get; }
+        private double _teleportTimer;
 
         public Ball(Point position, Vector velocity, JezzballTheme theme, BallType type = BallType.Normal, double radius = 8)
         {
@@ -383,6 +423,10 @@ namespace Cycloside.Plugins.BuiltIn
                 case BallType.Splitting:
                     Fill = theme.BallSplittingBrush;
                     break;
+                case BallType.Teleporting:
+                    Fill = theme.BallTeleportBrush;
+                    _teleportTimer = 2.0;
+                    break;
                 default:
                     Fill = theme.BallNormalBrush;
                     break;
@@ -396,6 +440,7 @@ namespace Cycloside.Plugins.BuiltIn
                 BallType.Slow => theme.BallSlowBrush,
                 BallType.Fast => theme.BallFastBrush,
                 BallType.Splitting => theme.BallSplittingBrush,
+                BallType.Teleporting => theme.BallTeleportBrush,
                 _ => theme.BallNormalBrush
             };
         }
@@ -404,6 +449,19 @@ namespace Cycloside.Plugins.BuiltIn
 
         public void Update(Rect bounds, double dt)
         {
+            if (Type == BallType.Teleporting)
+            {
+                _teleportTimer -= dt;
+                if (_teleportTimer <= 0)
+                {
+                    var rand = new Random();
+                    Position = new Point(
+                        rand.NextDouble() * (bounds.Width - Radius * 2) + bounds.Left + Radius,
+                        rand.NextDouble() * (bounds.Height - Radius * 2) + bounds.Top + Radius);
+                    _teleportTimer = 2.0;
+                }
+            }
+
             Position += Velocity * dt;
 
             if ((Position.X - Radius < bounds.Left && Velocity.X < 0) || (Position.X + Radius > bounds.Right && Velocity.X > 0))
@@ -440,6 +498,8 @@ namespace Cycloside.Plugins.BuiltIn
         public bool IsGameOver => Lives <= 0;
         public bool FlashEffect { get; set; }
         public bool HasIceWallPowerUp { get; private set; }
+        public bool FreezeActive { get; private set; }
+        public bool DoubleScoreActive { get; private set; }
 
         public IReadOnlyList<Ball> Balls => _balls;
         public IReadOnlyList<Rect> ActiveAreas => _activeAreas;
@@ -453,6 +513,8 @@ namespace Cycloside.Plugins.BuiltIn
         private readonly List<PowerUp> _powerUps = new();
         private double _totalPlayArea;
         private JezzballTheme _theme;
+        private double _freezeTimer;
+        private double _doubleScoreTimer;
 
         private const double WallSpeed = 150.0;
         private const double CaptureRequirement = 0.75;
@@ -485,6 +547,10 @@ namespace Cycloside.Plugins.BuiltIn
             _powerUps.Clear();
             CurrentWall = null;
             HasIceWallPowerUp = false;
+            FreezeActive = false;
+            DoubleScoreActive = false;
+            _freezeTimer = 0;
+            _doubleScoreTimer = 0;
             Message = $"Level {Level}";
 
             var bounds = new Rect(0, 0, gameSize.Width, gameSize.Height);
@@ -503,6 +569,7 @@ namespace Cycloside.Plugins.BuiltIn
                 if (Level > 1 && rand.NextDouble() > 0.7) type = BallType.Slow;
                 if (Level > 2 && rand.NextDouble() > 0.7) type = BallType.Fast;
                 if (Level > 3 && rand.NextDouble() > 0.8) type = BallType.Splitting;
+                if (Level > 4 && rand.NextDouble() > 0.85) type = BallType.Teleporting;
 
                 _balls.Add(new Ball(bounds.Center, velocity, _theme, type));
             }
@@ -520,7 +587,23 @@ namespace Cycloside.Plugins.BuiltIn
             var clickedPowerUp = _powerUps.FirstOrDefault(p => p.BoundingBox.Contains(clickPosition));
             if (clickedPowerUp != null)
             {
-                if (clickedPowerUp.Type == PowerUpType.IceWall) HasIceWallPowerUp = true;
+                switch (clickedPowerUp.Type)
+                {
+                    case PowerUpType.IceWall:
+                        HasIceWallPowerUp = true;
+                        break;
+                    case PowerUpType.ExtraLife:
+                        Lives++;
+                        break;
+                    case PowerUpType.Freeze:
+                        FreezeActive = true;
+                        _freezeTimer = 5.0;
+                        break;
+                    case PowerUpType.DoubleScore:
+                        DoubleScoreActive = true;
+                        _doubleScoreTimer = 10.0;
+                        break;
+                }
                 _powerUps.Remove(clickedPowerUp);
                 return;
             }
@@ -549,12 +632,34 @@ namespace Cycloside.Plugins.BuiltIn
                 return;
             }
 
+            if (FreezeActive)
+            {
+                _freezeTimer -= dt;
+                if (_freezeTimer <= 0)
+                {
+                    FreezeActive = false;
+                }
+            }
+
+            if (DoubleScoreActive)
+            {
+                _doubleScoreTimer -= dt;
+                if (_doubleScoreTimer <= 0)
+                {
+                    DoubleScoreActive = false;
+                }
+            }
+
             UpdateBalls(dt);
             UpdateWall(dt);
         }
 
         private void UpdateBalls(double dt)
         {
+            if (FreezeActive)
+            {
+                return;
+            }
             foreach (var ball in _balls.ToList())
             {
                 var area = _activeAreas.FirstOrDefault(r => r.Intersects(ball.BoundingBox));
@@ -658,16 +763,14 @@ namespace Cycloside.Plugins.BuiltIn
             if (ballsInArea1.Count == 0)
             {
                 _filledAreas.Add(newArea1);
-                if (ballsInArea2.Any(b => b.Type != BallType.Normal))
-                    _powerUps.Add(new PowerUp(newArea1.Center, PowerUpType.IceWall));
+                MaybeSpawnPowerUp(newArea1.Center);
             }
             else _activeAreas.Add(newArea1);
 
             if (ballsInArea2.Count == 0)
             {
                 _filledAreas.Add(newArea2);
-                if (ballsInArea1.Any(b => b.Type != BallType.Normal))
-                    _powerUps.Add(new PowerUp(newArea2.Center, PowerUpType.IceWall));
+                MaybeSpawnPowerUp(newArea2.Center);
             }
             else _activeAreas.Add(newArea2);
 
@@ -698,12 +801,31 @@ namespace Cycloside.Plugins.BuiltIn
             }
         }
 
+        private void MaybeSpawnPowerUp(Point location)
+        {
+            var rand = new Random();
+            if (rand.NextDouble() < 0.3)
+            {
+                var typeRoll = rand.Next(4);
+                var type = typeRoll switch
+                {
+                    0 => PowerUpType.IceWall,
+                    1 => PowerUpType.ExtraLife,
+                    2 => PowerUpType.Freeze,
+                    _ => PowerUpType.DoubleScore
+                };
+                _powerUps.Add(new PowerUp(location, type));
+            }
+        }
+
         private void RecalculateCapturedArea()
         {
             double filledAreaSum = _filledAreas.Sum(r => r.Width * r.Height);
             if (filledAreaSum > 0)
             {
-                Score += (long)filledAreaSum / 100;
+                var added = (long)filledAreaSum / 100;
+                if (DoubleScoreActive) added *= 2;
+                Score += added;
             }
             CapturedPercentage = _totalPlayArea > 0 ? filledAreaSum / _totalPlayArea : 0;
         }
@@ -730,6 +852,9 @@ namespace Cycloside.Plugins.BuiltIn
         private Pen _iceWallPen = null!;
         private Pen _icePreviewPen = null!;
         private IBrush _powerUpBrush = null!;
+        private IBrush _powerUpExtraLifeBrush = null!;
+        private IBrush _powerUpFreezeBrush = null!;
+        private IBrush _powerUpDoubleScoreBrush = null!;
         private readonly Menu _menu = new();
         private JezzballTheme _theme;
 
@@ -738,6 +863,7 @@ namespace Cycloside.Plugins.BuiltIn
         private readonly TextBlock _scoreText = new() { Margin = new Thickness(10, 0), Foreground = Brushes.WhiteSmoke };
         private readonly TextBlock _timeText = new() { Margin = new Thickness(10, 0), Foreground = Brushes.WhiteSmoke };
         private readonly TextBlock _capturedText = new() { Margin = new Thickness(10, 0), Foreground = Brushes.WhiteSmoke };
+        private readonly TextBlock _effectText = new() { Margin = new Thickness(10, 0), Foreground = Brushes.LightGreen };
 
         public Menu MenuBar => _menu;
 
@@ -755,7 +881,7 @@ namespace Cycloside.Plugins.BuiltIn
             DockPanel.SetDock(restartButton, Dock.Right);
             DockPanel.SetDock(_capturedText, Dock.Right);
             DockPanel.SetDock(_timeText, Dock.Right);
-            statusBar.Children.AddRange(new Control[] { _levelText, _livesText, _scoreText, restartButton, _capturedText, _timeText });
+            statusBar.Children.AddRange(new Control[] { _levelText, _livesText, _scoreText, restartButton, _capturedText, _timeText, _effectText });
 
             var layout = new DockPanel();
             DockPanel.SetDock(_menu, Dock.Top);
@@ -801,6 +927,9 @@ namespace Cycloside.Plugins.BuiltIn
             _iceWallPen = theme.IceWallPen;
             _icePreviewPen = theme.IcePreviewPen;
             _powerUpBrush = theme.PowerUpBrush;
+            _powerUpExtraLifeBrush = theme.ExtraLifeBrush;
+            _powerUpFreezeBrush = theme.FreezeBrush;
+            _powerUpDoubleScoreBrush = theme.DoubleScoreBrush;
         }
 
         public void RestartGame() => _gameState.StartLevel(this.Bounds.Size);
@@ -864,6 +993,10 @@ namespace Cycloside.Plugins.BuiltIn
             _scoreText.Text = $"Score: {_gameState.Score}";
             _timeText.Text = $"Time: {Math.Max(0, (int)_gameState.TimeLeft.TotalSeconds)}";
             _capturedText.Text = $"Captured: {_gameState.CapturedPercentage:P0}";
+            var effects = new List<string>();
+            if (_gameState.FreezeActive) effects.Add("Freeze");
+            if (_gameState.DoubleScoreActive) effects.Add("2x Score");
+            _effectText.Text = effects.Count > 0 ? $"Effects: {string.Join(", ", effects)}" : string.Empty;
         }
 
         internal async void RenderGame(DrawingContext context)
@@ -880,7 +1013,17 @@ namespace Cycloside.Plugins.BuiltIn
             }
 
             foreach (var ball in _gameState.Balls) context.DrawEllipse(ball.Fill, null, ball.Position, ball.Radius, ball.Radius);
-            foreach (var p in _gameState.PowerUps) context.DrawEllipse(_powerUpBrush, null, p.Position, p.Radius, p.Radius);
+            foreach (var p in _gameState.PowerUps)
+            {
+                var brush = p.Type switch
+                {
+                    PowerUpType.ExtraLife => _powerUpExtraLifeBrush,
+                    PowerUpType.Freeze => _powerUpFreezeBrush,
+                    PowerUpType.DoubleScore => _powerUpDoubleScoreBrush,
+                    _ => _powerUpBrush
+                };
+                context.DrawEllipse(brush, null, p.Position, p.Radius, p.Radius);
+            }
 
             if (_gameState.CurrentWall is { } wall)
             {


### PR DESCRIPTION
## Summary
- expand Jezzball gameplay with more ball types and powerups
- create new Retro theme and theme brush support for powerups
- spawn random powerups on area capture
- show active effects in the status bar

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v q` *(fails: 'RelayCommand' ambiguous reference)*

------
https://chatgpt.com/codex/tasks/task_e_6875d6022c388332a48bca30bbee73c3