### PR TITLE
Add sound effect support to Jezzball

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
+using ServicesRelayCommand = Cycloside.Services.RelayCommand;
 
 namespace Cycloside;
 
@@ -92,10 +93,10 @@ public partial class App : Application
             viewModel.WorkspaceItems.Remove(item);
         }
 
-        viewModel.ExitCommand = new RelayCommand(() => Shutdown());
+        viewModel.ExitCommand = new ServicesRelayCommand(() => Shutdown());
         
         // Toggle plugin enablement from the main window.
-        viewModel.StartPluginCommand = new RelayCommand(pluginObj =>
+        viewModel.StartPluginCommand = new ServicesRelayCommand(pluginObj =>
         {
             if (pluginObj is not IPlugin plugin || _pluginManager is null) return;
 
@@ -141,7 +142,7 @@ public partial class App : Application
         });
 
         // Start or stop a plugin in its own window, even if it supports the workspace.
-        viewModel.StartPluginWindowCommand = new RelayCommand(pluginObj =>
+        viewModel.StartPluginWindowCommand = new ServicesRelayCommand(pluginObj =>
         {
             if (pluginObj is not IPlugin plugin || _pluginManager is null) return;
 
@@ -322,9 +323,9 @@ public partial class App : Application
             Items =
             {
                 new NativeMenuItem("Settings") { Menu = new NativeMenu { Items = {
-                    new NativeMenuItem("Control Panel...") { Command = new RelayCommand(() => new ControlPanelWindow(manager).Show()) },
-                    new NativeMenuItem("Plugin Manager...") { Command = new RelayCommand(() => new PluginSettingsWindow(manager).Show()) },
-                    new NativeMenuItem("Theme Settings...") { Command = new RelayCommand(() => new ThemeSettingsWindow(manager).Show()) },
+                    new NativeMenuItem("Control Panel...") { Command = new ServicesRelayCommand(() => new ControlPanelWindow(manager).Show()) },
+                    new NativeMenuItem("Plugin Manager...") { Command = new ServicesRelayCommand(() => new PluginSettingsWindow(manager).Show()) },
+                    new NativeMenuItem("Theme Settings...") { Command = new ServicesRelayCommand(() => new ThemeSettingsWindow(manager).Show()) },
                 }}},
                 new NativeMenuItemSeparator(),
                 logsMenu, // **Add the new Logs menu here**
@@ -333,12 +334,12 @@ public partial class App : Application
                 new NativeMenuItemSeparator(),
                 pluginsMenu,
                 volatileMenu,
-                new NativeMenuItem("Open Plugins Folder") { Command = new RelayCommand(() => {
+                new NativeMenuItem("Open Plugins Folder") { Command = new ServicesRelayCommand(() => {
                     try { Process.Start(new ProcessStartInfo { FileName = manager.PluginDirectory, UseShellExecute = true }); } 
                     catch (Exception ex) { Logger.Log($"Failed to open plugin folder: {ex.Message}"); }
                 })},
                 new NativeMenuItemSeparator(),
-                new NativeMenuItem("Exit") { Command = new RelayCommand(() => Shutdown()) }
+                new NativeMenuItem("Exit") { Command = new ServicesRelayCommand(() => Shutdown()) }
             }
         };
     }
@@ -359,7 +360,7 @@ public partial class App : Application
             IsChecked = manager.IsEnabled(plugin)
         };
 
-        menuItem.Command = new RelayCommand(o =>
+        menuItem.Command = new ServicesRelayCommand(o =>
         {
             if (o is not NativeMenuItem item) return;
             

--- a/Cycloside/Plugins/BuiltIn/JezzballSound.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballSound.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Cycloside.Services;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+internal static class JezzballSound
+{
+    public static readonly Dictionary<JezzballSoundEvent, string> Paths = new();
+
+    public static void Play(JezzballSoundEvent ev)
+    {
+        if (Paths.TryGetValue(ev, out var path))
+        {
+            AudioService.Play(path);
+        }
+    }
+}

--- a/Cycloside/Services/AudioService.cs
+++ b/Cycloside/Services/AudioService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using NAudio.Wave;
+
+namespace Cycloside.Services;
+
+/// <summary>
+/// Simple audio playback helper for short sound effects.
+/// </summary>
+public static class AudioService
+{
+    /// <summary>
+    /// Plays the specified audio file if it exists.
+    /// </summary>
+    public static void Play(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return;
+        try
+        {
+            var reader = new AudioFileReader(path);
+            var output = new WaveOutEvent();
+            output.Init(reader);
+            output.Play();
+            output.PlaybackStopped += (_, _) =>
+            {
+                output.Dispose();
+                reader.Dispose();
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"Audio playback error for {path}: {ex.Message}");
+        }
+    }
+}

--- a/Cycloside/SettingsManager.cs
+++ b/Cycloside/SettingsManager.cs
@@ -36,6 +36,9 @@ public class AppSettings
     // Optional skin applied to plugin windows
     public Dictionary<string, string> PluginSkins { get; set; } = new();
 
+    // Sound effect files mapped by plugin name then event key
+    public Dictionary<string, Dictionary<string, string>> PluginSoundEffects { get; set; } = new();
+
     public string Cursor { get; set; } = "Arrow";
     public Dictionary<string, string> ComponentCursors { get; set; } = new();
     public Dictionary<string, List<string>> WindowEffects { get; set; } = new();


### PR DESCRIPTION
## Summary
- allow configuring sound effects for Jezzball events
- play sounds for wall building, hits, breaks, ball bounces and level completion
- reset level properly when continuing
- add AudioService helper and settings storage for plugin sound files
- fix RelayCommand ambiguity in App

## Testing
- `dotnet build Cycloside/Cycloside.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_6875d6022c388332a48bca30bbee73c3