### PR TITLE
Update docs for recent features

### DIFF
--- a/Cycloside/README.md
+++ b/Cycloside/README.md
@@ -24,10 +24,11 @@ Built-in examples:
 - **Wallpaper Changer** – set wallpapers on Windows, Linux or macOS
 - **ModPlug Tracker** – play `.mod`, `.it`, `.s3m` or `.xm` music modules
 - **Notification Center** – view messages from plugins and the core app
+- **Jezzball** – arcade game with powerups and Original Mode
 - **ScreenSaver Host** – run vintage 3D text and flower box screensavers
-- **Terminal** – simple shell window for running commands
+- **Terminal** - console with ANSI colour and scrollback
 - **Widget Host** – surface plugins as dockable widgets
-- **Winamp Visual Host** – run classic Winamp visualizer DLLs
+- **Winamp Visual Host** – run classic Winamp visualizer DLLs with MP3 integration
 
 ## 🗂️ Workspace Profiles
 

--- a/Cycloside/TODO.md
+++ b/Cycloside/TODO.md
@@ -26,10 +26,12 @@ This is a development checklist for your Avalonia-powered hacker’s paradise ap
     - [ ] TreeView/ListView for file system
     - [ ] Context menu (Open, Rename, Delete, etc.)
     - [ ] “Open in Code Editor” action
-- [~] **Terminal Emulator Plugin**
+- [x] **Terminal Emulator Plugin**
     - [x] Shell command execution
     - [x] Command history (arrow keys)
     - [x] Styled output (color text, scrollback)
+- [x] Jezzball plugin powerups, visual effects & Original Mode
+- [x] Winamp visualizer integration with MP3 player
 - [ ] **Network Tools Plugin**
     - [ ] Ping, traceroute utilities
     - [ ] Port scanner

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scriptin
 | `DiskUsagePlugin`        | Visualises folder sizes in a tree view.                                                  |
 | `EnvironmentEditorPlugin`| Edits environment variables at runtime (Process scope only on Linux/macOS).              |
 | `FileWatcherPlugin`      | Watches a directory and logs file system events.                                         |
-| `JezzballPlugin`         | Simple recreation of the classic game.                                                   |
+| `JezzballPlugin`         | Arcade game with powerups, visual effects and Original mode.|
 | `LogViewerPlugin`        | Tails a log file and filters lines on the fly.                                           |
 | `NotificationCenterPlugin`| Aggregates messages broadcast via `NotificationCenter`.                                  |
 | `MP3PlayerPlugin`        | Basic audio player built on NAudio.                                                      |
@@ -87,10 +87,10 @@ For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scriptin
 | `ScreenSaverPlugin`      | Runs full-screen screensavers after a period of inactivity.                              |
 | `TaskSchedulerPlugin`    | Schedules tasks with cron-style expressions.                                             |
 | `TextEditorPlugin`       | Notepad-like editor supporting multiple files.                                           |
-| `TerminalPlugin`         | Run shell commands in a simple console window.                                           |
+| `TerminalPlugin`         | Console with ANSI colour and scrollback.|
 | `WallpaperPlugin`        | Changes the desktop wallpaper periodically.                                              |
 | `WidgetHostPlugin`       | Hosts small widgets inside dockable panels.                                              |
-| `WinampVisHostPlugin`    | Runs Winamp AVS visualisation presets.                                                   |
+| `WinampVisHostPlugin`    | Winamp visualisations integrated with the MP3 player.|
 
 </details>
 
@@ -100,3 +100,4 @@ Ensure the .NET 8 SDK is installed (download from https://dotnet.microsoft.com/d
 
 ```bash
 dotnet build Cycloside/Cycloside.csproj
+```


### PR DESCRIPTION
## Summary
- highlight new Jezzball, Terminal and Winamp plugin features in README
- expand example plugin list with Jezzball and updated descriptions
- mark Terminal plugin done in TODO and log new improvements
- fix README code block formatting

## Testing
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68792c7d1aa883329c88dbfd55f599eb