### PR TITLE
Add Encryption plugin

### DIFF
--- a/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
@@ -130,6 +130,7 @@ namespace Cycloside.Plugins.BuiltIn
                         _outputBox.Text = csWriter.ToString() + (csResult != null ? csResult.ToString() : string.Empty);
                         break;
                     case "Python":
+                    {
                         var engine = Python.CreateEngine();
                         using var stream = new MemoryStream();
                         engine.Runtime.IO.SetOutput(stream, Encoding.UTF8);
@@ -141,6 +142,7 @@ namespace Cycloside.Plugins.BuiltIn
                         var output = new StreamReader(stream).ReadToEnd();
                         _outputBox.Text = output + (pyResult != null ? pyResult.ToString() : string.Empty);
                         break;
+                    }
                     case "JavaScript":
                         var sb = new StringBuilder();
                         var jsEngine = new Engine();

--- a/Cycloside/Plugins/BuiltIn/EncryptionPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EncryptionPlugin.cs
@@ -1,0 +1,222 @@
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Cycloside.Services;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public class EncryptionPlugin : IPlugin
+{
+    private EncryptionWindow? _window;
+    private TextBox? _inputBox;
+    private TextBox? _keyBox;
+    private TextBox? _outputBox;
+    private ComboBox? _algorithmBox;
+    private Action<object?>? _encryptFileHandler;
+    private Action<object?>? _decryptFileHandler;
+
+    public string Name => "Encryption";
+    public string Description => "AES/RSA text and file encryption";
+    public Version Version => new(0, 1, 0);
+    public Widgets.IWidget? Widget => null;
+    public bool ForceDefaultTheme => false;
+
+    public void Start()
+    {
+        _window = new EncryptionWindow();
+        _inputBox = _window.FindControl<TextBox>("InputBox");
+        _keyBox = _window.FindControl<TextBox>("KeyBox");
+        _outputBox = _window.FindControl<TextBox>("OutputBox");
+        _algorithmBox = _window.FindControl<ComboBox>("AlgorithmBox");
+        var encBtn = _window.FindControl<Button>("EncryptButton");
+        var decBtn = _window.FindControl<Button>("DecryptButton");
+        if (encBtn != null)
+            encBtn.Click += async (_, _) => await EncryptTextAsync();
+        if (decBtn != null)
+            decBtn.Click += async (_, _) => await DecryptTextAsync();
+
+        _encryptFileHandler = async o =>
+        {
+            if (o is string path && File.Exists(path))
+                await EncryptFileAsync(path);
+        };
+        _decryptFileHandler = async o =>
+        {
+            if (o is string path && File.Exists(path))
+                await DecryptFileAsync(path);
+        };
+        PluginBus.Subscribe("encryption:encryptFile", _encryptFileHandler);
+        PluginBus.Subscribe("encryption:decryptFile", _decryptFileHandler);
+        WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(EncryptionPlugin));
+        _window.Show();
+    }
+
+    public void Stop()
+    {
+        _window?.Close();
+        _window = null;
+        if (_encryptFileHandler != null)
+        {
+            PluginBus.Unsubscribe("encryption:encryptFile", _encryptFileHandler);
+            _encryptFileHandler = null;
+        }
+        if (_decryptFileHandler != null)
+        {
+            PluginBus.Unsubscribe("encryption:decryptFile", _decryptFileHandler);
+            _decryptFileHandler = null;
+        }
+    }
+
+    private string SelectedAlgorithm() =>
+        (_algorithmBox?.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "AES";
+
+    private async Task EncryptTextAsync()
+    {
+        if (_inputBox == null || _keyBox == null || _outputBox == null) return;
+        try
+        {
+            var data = Encoding.UTF8.GetBytes(_inputBox.Text);
+            var result = EncryptBytes(data, _keyBox.Text, SelectedAlgorithm());
+            _outputBox.Text = Convert.ToBase64String(result);
+        }
+        catch (Exception ex)
+        {
+            _outputBox.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private async Task DecryptTextAsync()
+    {
+        if (_inputBox == null || _keyBox == null || _outputBox == null) return;
+        try
+        {
+            var data = Convert.FromBase64String(_inputBox.Text);
+            var result = DecryptBytes(data, _keyBox.Text, SelectedAlgorithm());
+            _outputBox.Text = Encoding.UTF8.GetString(result);
+        }
+        catch (Exception ex)
+        {
+            _outputBox.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private async Task EncryptFileAsync(string path)
+    {
+        if (_window == null || _keyBox == null) return;
+        var start = await DialogHelper.GetDefaultStartLocationAsync(_window.StorageProvider);
+        var file = await _window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save Encrypted File",
+            SuggestedFileName = Path.GetFileName(path) + ".enc",
+            SuggestedStartLocation = start
+        });
+        if (file?.TryGetLocalPath() is not { } dest) return;
+        try
+        {
+            var data = await File.ReadAllBytesAsync(path);
+            var result = EncryptBytes(data, _keyBox.Text, SelectedAlgorithm());
+            await File.WriteAllBytesAsync(dest, result);
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"Encrypt file error: {ex.Message}");
+        }
+    }
+
+    private async Task DecryptFileAsync(string path)
+    {
+        if (_window == null || _keyBox == null) return;
+        var start = await DialogHelper.GetDefaultStartLocationAsync(_window.StorageProvider);
+        var file = await _window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save Decrypted File",
+            SuggestedFileName = Path.GetFileNameWithoutExtension(path),
+            SuggestedStartLocation = start
+        });
+        if (file?.TryGetLocalPath() is not { } dest) return;
+        try
+        {
+            var data = await File.ReadAllBytesAsync(path);
+            var result = DecryptBytes(data, _keyBox.Text, SelectedAlgorithm());
+            await File.WriteAllBytesAsync(dest, result);
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"Decrypt file error: {ex.Message}");
+        }
+    }
+
+    private static byte[] EncryptBytes(byte[] data, string key, string algorithm)
+    {
+        return algorithm == "RSA" ? RsaEncrypt(data, key) : AesEncrypt(data, key);
+    }
+
+    private static byte[] DecryptBytes(byte[] data, string key, string algorithm)
+    {
+        return algorithm == "RSA" ? RsaDecrypt(data, key) : AesDecrypt(data, key);
+    }
+
+    private static byte[] AesEncrypt(byte[] data, string key)
+    {
+        using var aes = Aes.Create();
+        aes.Key = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        aes.GenerateIV();
+        using var ms = new MemoryStream();
+        ms.Write(aes.IV, 0, aes.IV.Length);
+        using var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write);
+        cs.Write(data, 0, data.Length);
+        cs.FlushFinalBlock();
+        return ms.ToArray();
+    }
+
+    private static byte[] AesDecrypt(byte[] data, string key)
+    {
+        using var aes = Aes.Create();
+        aes.Key = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        var ivLength = aes.BlockSize / 8;
+        var iv = data.AsSpan(0, ivLength).ToArray();
+        aes.IV = iv;
+        using var ms = new MemoryStream();
+        using var cs = new CryptoStream(new MemoryStream(data, ivLength, data.Length - ivLength), aes.CreateDecryptor(), CryptoStreamMode.Read);
+        cs.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    private static byte[] RsaEncrypt(byte[] data, string key)
+    {
+        using var rsa = RSA.Create();
+        ImportKey(rsa, key);
+        return rsa.Encrypt(data, RSAEncryptionPadding.OaepSHA256);
+    }
+
+    private static byte[] RsaDecrypt(byte[] data, string key)
+    {
+        using var rsa = RSA.Create();
+        ImportKey(rsa, key);
+        return rsa.Decrypt(data, RSAEncryptionPadding.OaepSHA256);
+    }
+
+    private static void ImportKey(RSA rsa, string key)
+    {
+        try
+        {
+            rsa.ImportFromPem(key.ToCharArray());
+        }
+        catch
+        {
+            try
+            {
+                rsa.FromXmlString(key);
+            }
+            catch
+            {
+                // unsupported key format
+                throw new InvalidOperationException("Invalid RSA key format");
+            }
+        }
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/FileExplorerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/FileExplorerPlugin.cs
@@ -168,6 +168,26 @@ public class FileExplorerPlugin : IPlugin, IDisposable
         }
     }
 
+    private void EncryptSelected()
+    {
+        if (_list?.SelectedItem is not string item) return;
+        var path = Path.Combine(_currentPath, item);
+        if (File.Exists(path))
+        {
+            PluginBus.Publish("encryption:encryptFile", path);
+        }
+    }
+
+    private void DecryptSelected()
+    {
+        if (_list?.SelectedItem is not string item) return;
+        var path = Path.Combine(_currentPath, item);
+        if (File.Exists(path))
+        {
+            PluginBus.Publish("encryption:decryptFile", path);
+        }
+    }
+
     private async Task<string?> PromptAsync(string title, string initial)
     {
         if (_window == null) return null;
@@ -209,7 +229,9 @@ public class FileExplorerPlugin : IPlugin, IDisposable
                 new MenuItem { Header = "Open", Command = ReactiveCommand.Create(OpenSelected) },
                 new MenuItem { Header = "Rename", Command = ReactiveCommand.Create(RenameSelected) },
                 new MenuItem { Header = "Delete", Command = ReactiveCommand.Create(DeleteSelected) },
-                new MenuItem { Header = "Open in Code Editor", Command = ReactiveCommand.Create(OpenInEditor) }
+                new MenuItem { Header = "Open in Code Editor", Command = ReactiveCommand.Create(OpenInEditor) },
+                new MenuItem { Header = "Encrypt File", Command = ReactiveCommand.Create(EncryptSelected) },
+                new MenuItem { Header = "Decrypt File", Command = ReactiveCommand.Create(DecryptSelected) }
             }
         };
     }

--- a/Cycloside/Plugins/BuiltIn/Views/EncryptionWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/EncryptionWindow.axaml
@@ -1,0 +1,19 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Cycloside.Plugins.BuiltIn.EncryptionWindow"
+        Title="Encryption"
+        Width="600" Height="500">
+    <StackPanel Margin="5" Spacing="5">
+        <ComboBox x:Name="AlgorithmBox" SelectedIndex="0">
+            <ComboBoxItem Content="AES"/>
+            <ComboBoxItem Content="RSA"/>
+        </ComboBox>
+        <TextBox x:Name="KeyBox" Watermark="Key or PEM/XML" AcceptsReturn="True" Height="60"/>
+        <TextBox x:Name="InputBox" AcceptsReturn="True" Height="120" Watermark="Input"/>
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <Button x:Name="EncryptButton" Content="Encrypt"/>
+            <Button x:Name="DecryptButton" Content="Decrypt"/>
+        </StackPanel>
+        <TextBox x:Name="OutputBox" AcceptsReturn="True" Height="120" IsReadOnly="True" Watermark="Output"/>
+    </StackPanel>
+</Window>

--- a/Cycloside/Plugins/BuiltIn/Views/EncryptionWindow.axaml.cs
+++ b/Cycloside/Plugins/BuiltIn/Views/EncryptionWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Cycloside.Plugins.BuiltIn;
+
+public partial class EncryptionWindow : Window
+{
+    public EncryptionWindow()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EncryptionPlugin` with AES/RSA support
- create `EncryptionWindow` UI for text encryption
- integrate file encryption through `PluginBus` events
- extend File Explorer context menu with Encrypt/Decrypt options
- fix `CodeEditorPlugin` switch-case using braces

## Testing
- `dotnet build Cycloside/Cycloside.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_687942d2f9508332bbeca23d7f78eae2