### PR TITLE
Update SDK template and docs after plugin additions

### DIFF
--- a/Cycloside/Program.cs
+++ b/Cycloside/Program.cs
@@ -50,6 +50,8 @@ public class {name} : IPlugin
     public string Name => ""{name}"";
     public string Description => ""Describe your plugin."";
     public Version Version => new(1, 0, 0);
+    public Cycloside.Widgets.IWidget? Widget => null;
+    public bool ForceDefaultTheme => false;
 
     public void Start()
     {{

--- a/Cycloside/SDK/README.md
+++ b/Cycloside/SDK/README.md
@@ -3,13 +3,15 @@
 This folder contains the minimal interfaces needed to build external plugins.
 Reference `Cycloside.dll` and implement `Cycloside.Plugins.IPlugin`.
 The interface exposes metadata, lifecycle methods and an optional `Widget`
-surface for dockable controls. For advanced hooks implement
+surface for dockable controls. Set `ForceDefaultTheme` to `true` if your
+plugin should ignore component skins. For advanced hooks implement
 `IPluginExtended`.
 
 ## Getting Started
 
 1. Run `dotnet run -- --newplugin MyPlugin` from the repository root to generate
-   a template plugin inside `Plugins/`.
+   a template plugin inside `Plugins/`. Add `--with-tests` to include a test
+   project.
 2. Implement the methods in the generated class and compile it into its own DLL.
 3. Place the compiled DLL back in the `Plugins/` folder and use **Settings →
    Plugin Manager** to enable or disable it. Dependencies should sit beside the

--- a/Cycloside/TODO.md
+++ b/Cycloside/TODO.md
@@ -32,14 +32,14 @@ This is a development checklist for your Avalonia-powered hacker’s paradise ap
     - [x] Styled output (color text, scrollback)
 - [x] Jezzball plugin powerups, visual effects & Original Mode
 - [x] Winamp visualizer integration with MP3 player
-- [ ] **Network Tools Plugin**
-    - [ ] Ping, traceroute utilities
-    - [ ] Port scanner
-    - [ ] Export/save results to file
-- [ ] **Encryption Plugin**
-    - [ ] AES/RSA text and file encryption
-    - [ ] UI for entering data, key, selecting algorithm
-    - [ ] Integrate with File Explorer for file encryption
+- [x] **Network Tools Plugin**
+    - [x] Ping, traceroute utilities
+    - [x] Port scanner
+    - [x] Export/save results to file
+- [x] **Encryption Plugin**
+    - [x] AES/RSA text and file encryption
+    - [x] UI for entering data, key, selecting algorithm
+    - [x] Integrate with File Explorer for file encryption
 
 ## Marketplace & Extensibility
 - [ ] Design plugin marketplace UI (browse, install, update, remove plugins)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scriptin
 <details><summary>Core</summary>
 
 * Built-in plugin system with hot reload. Sample modules include a clock overlay,
-    MP3 player, macro recorder (Windows only), text editor, wallpaper changer,
+    MP3 player, macro recorder (Windows only), text editor, **code editor**,
+    wallpaper changer, **file explorer**, **network tools**, **encryption helper**,
     widget host, Winamp visualizer host, a tracker module player and a simple
     command shell.
 * Workspace profiles remember your wallpaper and plugin states for quick swaps.
@@ -77,6 +78,9 @@ For volatile scripting see [`docs/volatile-scripting.md`](docs/volatile-scriptin
 | `DiskUsagePlugin`        | Visualises folder sizes in a tree view.                                                  |
 | `EnvironmentEditorPlugin`| Edits environment variables at runtime (Process scope only on Linux/macOS).              |
 | `FileWatcherPlugin`      | Watches a directory and logs file system events.                                         |
+| `FileExplorerPlugin`     | Browse directories with tree and list views, context menu actions. |
+| `NetworkToolsPlugin`     | Ping, traceroute and port scan utilities with export. |
+| `EncryptionPlugin`       | Encrypt text or files using AES/RSA. Accessible from File Explorer. |
 | `JezzballPlugin`         | Arcade game with powerups, visual effects and Original mode.|
 | `LogViewerPlugin`        | Tails a log file and filters lines on the fly.                                           |
 | `NotificationCenterPlugin`| Aggregates messages broadcast via `NotificationCenter`.                                  |


### PR DESCRIPTION
## Summary
- expand SDK README with ForceDefaultTheme mention and test option
- update plugin template to expose Widget and ForceDefaultTheme
- mark completed plugins in TODO
- document new built-in plugins in README

## Testing
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687947bd066083329560fbef0591a9f8