### PR TITLE
Improve hotkey support and QuickLauncher reliability

### DIFF
--- a/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia;
+using Cycloside;
 using Cycloside.Services;
 using System;
 using System.Linq;
@@ -28,6 +29,12 @@ public class QuickLauncherPlugin : IPlugin
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(QuickLauncherPlugin));
 
         var panel = _window.FindControl<StackPanel>("ButtonsPanel");
+        if (panel is null)
+        {
+            Logger.Log("QuickLauncher: ButtonsPanel not found.");
+            return;
+        }
+
         foreach (var plugin in _manager.Plugins.Where(p => p != this))
         {
             var button = new Button { Content = plugin.Name, Margin = new Thickness(0, 0, 4, 0) };

--- a/Cycloside/README.md
+++ b/Cycloside/README.md
@@ -80,7 +80,8 @@ curl -X POST -H "X-Api-Token: <token>" http://localhost:4123/trigger -d "my:even
 Cycloside registers system-wide shortcuts using Avalonia's hotkey framework.
 On macOS a small Swift helper hooks into `NSEvent` so hotkeys fire even when
 the application is unfocused. Press **Ctrl+Alt+W** at any time to summon the
-widget host. Profiles and other features can be wired up to custom hotkeys.
+widget host or **Ctrl+Alt+T** to pop open a terminal. Profiles and other
+features can be wired up to custom hotkeys.
 Use **Settings → Hotkey Settings** to remap shortcuts from the GUI.
 The helper source lives in `Hotkeys/HotkeyMonitor.swift` and should be built as
 `libHotkeyMonitor.dylib` placed next to the application binary.

--- a/Cycloside/SettingsManager.cs
+++ b/Cycloside/SettingsManager.cs
@@ -48,7 +48,8 @@ public class AppSettings
     /// </summary>
     public Dictionary<string, string> Hotkeys { get; set; } = new()
     {
-        { "WidgetHost", "Ctrl+Alt+W" }
+        { "WidgetHost", "Ctrl+Alt+W" },
+        { "Terminal", "Ctrl+Alt+T" }
     };
     public double WeatherLatitude { get; set; } = 35;
     public double WeatherLongitude { get; set; } = 139;


### PR DESCRIPTION
## Summary
- guard QuickLauncher panel lookup and log when missing
- add default Ctrl+Alt+T hotkey to launch Terminal
- document new terminal hotkey in README

## Testing
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688fa75af1c48332ada693d0cee3f427