### PR TITLE
Add QuickLauncher hotkey and state highlight

### DIFF
--- a/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia;
+using Avalonia.Media;
+using Cycloside;
 using Cycloside.Services;
 using System;
 using System.Linq;
@@ -28,16 +30,34 @@ public class QuickLauncherPlugin : IPlugin
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(QuickLauncherPlugin));
 
         var panel = _window.FindControl<StackPanel>("ButtonsPanel");
+        if (panel is null)
+        {
+            Logger.Log("QuickLauncher: ButtonsPanel not found.");
+            return;
+        }
+
         foreach (var plugin in _manager.Plugins.Where(p => p != this))
         {
             var button = new Button { Content = plugin.Name, Margin = new Thickness(0, 0, 4, 0) };
+
+            void UpdateState()
+            {
+                button.Background = _manager.IsEnabled(plugin)
+                    ? Brushes.LimeGreen
+                    : Brushes.Gray;
+            }
+
+            UpdateState();
+
             button.Click += (_, _) =>
             {
                 if (_manager.IsEnabled(plugin))
                     _manager.DisablePlugin(plugin);
                 else
                     _manager.EnablePlugin(plugin);
+                UpdateState();
             };
+
             panel.Children.Add(button);
         }
         _window.Show();

--- a/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
@@ -134,7 +134,8 @@ public class TerminalPlugin : IPlugin
                 var run = new Run(segment);
                 if (color.HasValue)
                     run.Foreground = new SolidColorBrush(color.Value);
-                block.Inlines.Add(run);
+                // Safeguard in case Inlines collection is unexpectedly null
+                block.Inlines?.Add(run);
             }
             _outputPanel.Children.Add(block);
         }

--- a/Cycloside/README.md
+++ b/Cycloside/README.md
@@ -79,8 +79,11 @@ curl -X POST -H "X-Api-Token: <token>" http://localhost:4123/trigger -d "my:even
 
 Cycloside registers system-wide shortcuts using Avalonia's hotkey framework.
 On macOS a small Swift helper hooks into `NSEvent` so hotkeys fire even when
-the application is unfocused. Press **Ctrl+Alt+W** at any time to summon the
-widget host. Profiles and other features can be wired up to custom hotkeys.
+the application is unfocused. Press **Ctrl+Alt+W** to summon the
+widget host, **Ctrl+Alt+T** to pop open a terminal, **Ctrl+Alt+E**
+to bring up the file explorer, **Ctrl+Alt+N** for a fresh text editor,
+or **Ctrl+Alt+Q** to toggle the Quick Launcher. Profiles and other
+features can be wired up to custom hotkeys.
 Use **Settings → Hotkey Settings** to remap shortcuts from the GUI.
 The helper source lives in `Hotkeys/HotkeyMonitor.swift` and should be built as
 `libHotkeyMonitor.dylib` placed next to the application binary.

--- a/Cycloside/SettingsManager.cs
+++ b/Cycloside/SettingsManager.cs
@@ -48,7 +48,11 @@ public class AppSettings
     /// </summary>
     public Dictionary<string, string> Hotkeys { get; set; } = new()
     {
-        { "WidgetHost", "Ctrl+Alt+W" }
+        { "WidgetHost", "Ctrl+Alt+W" },
+        { "Terminal", "Ctrl+Alt+T" },
+        { "FileExplorer", "Ctrl+Alt+E" },
+        { "TextEditor", "Ctrl+Alt+N" },
+        { "QuickLauncher", "Ctrl+Alt+Q" }
     };
     public double WeatherLatitude { get; set; } = 35;
     public double WeatherLongitude { get; set; } = 139;


### PR DESCRIPTION
## Summary
- color-code Quick Launcher buttons based on plugin enabled state
- add default Ctrl+Alt+Q hotkey for Quick Launcher and document it
- add global hotkeys for File Explorer and Text Editor
- harden Terminal plugin output rendering to avoid null reference

## Testing
- `dotnet --version`
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688fa75af1c48332ada693d0cee3f427