### PR TITLE
Set Winamp vis plugin channel counts

### DIFF
--- a/Cycloside/Visuals/WinampVisPluginAdapter.cs
+++ b/Cycloside/Visuals/WinampVisPluginAdapter.cs
@@ -58,6 +58,8 @@ public class WinampVisPluginAdapter
         _module.hwndParent = IntPtr.Zero;
         _module.sRate = 44100;
         _module.nCh = 2;
+        _module.spectrumNch = 2;
+        _module.waveformNch = 2;
         _module.spectrumData = new byte[1152];
         _module.waveformData = new byte[1152];
         return true;


### PR DESCRIPTION
## Summary
- tell Winamp vis adapter about stereo channel counts so visuals get audio

## Testing
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6890ed1a47b48332a3102b2819b34040