### PR TITLE
Ensure consistent theming across plugin windows

### DIFF
--- a/Cycloside/Plugins/BuiltIn/CharacterMapPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/CharacterMapPlugin.cs
@@ -45,6 +45,7 @@ namespace Cycloside.Plugins.BuiltIn
             LoadCharacters();
 
             _window = new CharacterMapWindow { DataContext = this };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(CharacterMapPlugin));
             _window.Show();
         }

--- a/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ClipboardManagerPlugin.cs
@@ -52,6 +52,7 @@ namespace Cycloside.Plugins.BuiltIn
         {
             // The ViewModel's job is to create its View and set the DataContext.
             _window = new ClipboardManagerWindow { DataContext = this };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(ClipboardManagerPlugin));
             _window.Show();
 

--- a/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
@@ -39,6 +39,7 @@ namespace Cycloside.Plugins.BuiltIn
             _outputBox = _window.FindControl<TextBox>("OutputBox");
             _languageBox!.SelectedIndex = 0; // default C#
             _languageBox.SelectionChanged += (_, _) => UpdateHighlighting();
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(CodeEditorPlugin));
             _window.Show();
             UpdateHighlighting();

--- a/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
@@ -35,6 +35,7 @@ namespace Cycloside.Plugins.BuiltIn
         public void Start()
         {
             _window = new DateTimeOverlayWindow { DataContext = this };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DateTimeOverlayPlugin));
             
             // Set up the timer

--- a/Cycloside/Plugins/BuiltIn/EncryptionPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EncryptionPlugin.cs
@@ -51,6 +51,7 @@ public class EncryptionPlugin : IPlugin
         };
         PluginBus.Subscribe("encryption:encryptFile", _encryptFileHandler);
         PluginBus.Subscribe("encryption:decryptFile", _decryptFileHandler);
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(EncryptionPlugin));
         _window.Show();
     }

--- a/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Cycloside.Services;
 using ReactiveUI;
 using System;
 using System.Collections;
@@ -67,6 +68,7 @@ namespace Cycloside.Plugins.BuiltIn
             }
 
             LoadVariables();
+            ThemeManager.ApplyForPlugin(_window, this);
             _window.Show();
         }
 

--- a/Cycloside/Plugins/BuiltIn/FileExplorerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/FileExplorerPlugin.cs
@@ -49,6 +49,7 @@ public class FileExplorerPlugin : IPlugin, IDisposable
             _tree.DoubleTapped += (_, __) => UpdatePathFromTree();
             PopulateTree();
         }
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(FileExplorerPlugin));
         _window.Show();
         RefreshList();

--- a/Cycloside/Plugins/BuiltIn/FileWatcherPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/FileWatcherPlugin.cs
@@ -34,6 +34,7 @@ namespace Cycloside.Plugins.BuiltIn
             clearLogButton?.AddHandler(Button.ClickEvent, (s, e) => { if (_log != null) _log.Text = string.Empty; });
             saveLogButton?.AddHandler(Button.ClickEvent, async (s, e) => await SaveLogAsync());
 
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(FileWatcherPlugin));
             _window.Show();
         }

--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -59,10 +59,7 @@ namespace Cycloside.Plugins.BuiltIn
             };
 
             ThemeManager.ApplyForPlugin(_window, this);
-            if (SettingsManager.Settings.PluginSkins.TryGetValue("Jezzball", out var skin))
-            {
-                SkinManager.ApplySkinTo(_window, skin);
-            }
+            SettingsManager.Settings.PluginSkins.TryGetValue("Jezzball", out var skin);
             BuildMenu(themeName, skin);
             _window.KeyDown += OnWindowKeyDown;
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
@@ -54,7 +54,7 @@ namespace Cycloside.Plugins.BuiltIn
         public void Start()
         {
             _window = new LogViewerWindow();
-            
+            ThemeManager.ApplyForPlugin(_window, this);
             var openButton = new Button { Content = "Open Log File" };
             openButton.Click += async (s, e) => await SelectAndLoadFileAsync();
 

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -156,6 +156,7 @@ namespace Cycloside.Plugins.BuiltIn
             }
 
             _window = new Views.MP3PlayerWindow { DataContext = this };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
             _window.Closed += (_, _) => _window = null;
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -96,6 +96,7 @@ public class MacroPlugin : IPlugin
         _window.FindControl<AvaloniaButton>("ReloadButton")?.AddHandler(AvaloniaButton.ClickEvent, (_, __) => { MacroManager.Reload(); RefreshList(); });
         _window.FindControl<AvaloniaButton>("DeleteButton")?.AddHandler(AvaloniaButton.ClickEvent, (_, __) => DeleteSelected());
 
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(MacroPlugin));
         _window.Show();
     }

--- a/Cycloside/Plugins/BuiltIn/ModTrackerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ModTrackerPlugin.cs
@@ -100,6 +100,7 @@ namespace Cycloside.Plugins.BuiltIn
             }
             
             _window = BuildTrackerWindow();
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
             _window.Closed += (s, e) => Stop();
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/NetworkToolsPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/NetworkToolsPlugin.cs
@@ -49,6 +49,7 @@ public class NetworkToolsPlugin : IPlugin
         _window.FindControl<Button>("MacButton")?.AddHandler(Button.ClickEvent, MacClicked);
         _window.FindControl<Button>("ExportButton")?.AddHandler(Button.ClickEvent, ExportClicked);
 
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(NetworkToolsPlugin));
         _window.Show();
     }

--- a/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
@@ -36,6 +36,7 @@ public class NotificationCenterPlugin : IPlugin, IDisposable, IWorkspaceItem
             return;
         }
         _window = new Views.NotificationCenterWindow { DataContext = this };
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
         _window.Closed += (_, _) => _window = null;
         _window.Show();

--- a/Cycloside/Plugins/BuiltIn/ProcessMonitorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ProcessMonitorPlugin.cs
@@ -38,6 +38,7 @@ namespace Cycloside.Plugins.BuiltIn
         public void Start()
         {
             _window = new ProcessMonitorWindow { DataContext = this };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(ProcessMonitorPlugin));
             _window.Show();
 

--- a/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/QuickLauncherPlugin.cs
@@ -27,6 +27,7 @@ public class QuickLauncherPlugin : IPlugin
     public void Start()
     {
         _window = new Views.QuickLauncherWindow();
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(QuickLauncherPlugin));
 
         var panel = _window.FindControl<StackPanel>("ButtonsPanel");

--- a/Cycloside/Plugins/BuiltIn/TaskSchedulerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TaskSchedulerPlugin.cs
@@ -28,6 +28,7 @@ public class TaskSchedulerPlugin : IPlugin
             if (!string.IsNullOrWhiteSpace(_cmdBox?.Text) && !string.IsNullOrWhiteSpace(_timeBox?.Text))
                 AddTask(_cmdBox!.Text, _timeBox!.Text);
         });
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(TaskSchedulerPlugin));
         _window.Show();
     }

--- a/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TerminalPlugin.cs
@@ -40,6 +40,7 @@ public class TerminalPlugin : IPlugin
         {
             _inputBox.KeyDown += OnInputKeyDown;
         }
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(TerminalPlugin));
         _window.Show();
     }

--- a/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
@@ -49,6 +49,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 DataContext = this
             };
+            ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(TextEditorPlugin));
             _window.Show();
 

--- a/Cycloside/Plugins/BuiltIn/WidgetHostPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WidgetHostPlugin.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Cycloside.Services;
 using Cycloside.Widgets;
 using System;
 
@@ -34,6 +35,7 @@ public class WidgetHostPlugin : IPlugin
         _manager = new WidgetManager();
         _manager.LoadBuiltIn();
         _window = new WidgetHostWindow();
+        ThemeManager.ApplyForPlugin(_window, this);
         WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(WidgetHostPlugin));
         var canvas = _window.Root;
         double x = 10;

--- a/Cycloside/Services/ThemeManager.cs
+++ b/Cycloside/Services/ThemeManager.cs
@@ -106,6 +106,11 @@ namespace Cycloside.Services
 
             ApplyComponentTheme(window, "Plugins");
             ApplyComponentTheme(window, plugin.Name);
+
+            if (SettingsManager.Settings.PluginSkins.TryGetValue(plugin.Name, out var skin) && !string.IsNullOrEmpty(skin))
+            {
+                SkinManager.ApplySkinTo(window, skin);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- centralize skin application so plugins automatically load configured skins
- wire ThemeManager into every built-in plugin window for consistent theming

## Testing
- `dotnet --version`
- `dotnet build Cycloside/Cycloside.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689114f1aab883328161496355069034