### PR TITLE
Refactor screensaver framework and add sample modules

### DIFF
--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/BouncingBallAnimation.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/BouncingBallAnimation.cs
@@ -1,0 +1,41 @@
+using System;
+using Avalonia;
+using Avalonia.Media;
+
+namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
+{
+    internal class BouncingBallAnimation : IScreenSaverModule
+    {
+        private double _x;
+        private double _y;
+        private double _vx;
+        private double _vy;
+        private readonly Random _random = new();
+        public string Name => "BouncingBall";
+
+        public BouncingBallAnimation()
+        {
+            _x = _random.NextDouble();
+            _y = _random.NextDouble();
+            _vx = (_random.NextDouble() - 0.5) * 0.02;
+            _vy = (_random.NextDouble() - 0.5) * 0.02;
+        }
+
+        public void Update()
+        {
+            _x += _vx;
+            _y += _vy;
+            if (_x < 0 || _x > 1) _vx = -_vx;
+            if (_y < 0 || _y > 1) _vy = -_vy;
+        }
+
+        public void Render(DrawingContext context, Rect bounds)
+        {
+            double radius = Math.Min(bounds.Width, bounds.Height) * 0.05;
+            var cx = bounds.X + _x * bounds.Width;
+            var cy = bounds.Y + _y * bounds.Height;
+            var brush = Brushes.CornflowerBlue;
+            context.DrawEllipse(brush, null, new Point(cx, cy), radius, radius);
+        }
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/DecoAnimation.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/DecoAnimation.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Media;
+
+// Ported from XScreenSaver's "deco" module.
+// Draws recursively subdivided rectangles with random colors.
+// This is a simplified C# implementation for the Cycloside screensaver host.
+
+namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
+{
+    internal class DecoAnimation : IScreenSaverModule
+    {
+        private readonly Random _random = new();
+        private readonly List<Rect> _rects = new();
+        private readonly IBrush[] _palette =
+        {
+            Brushes.Red,
+            Brushes.Yellow,
+            Brushes.Blue,
+            Brushes.White,
+            Brushes.Black
+        };
+
+        public string Name => "Deco";
+
+        public void Update()
+        {
+            _rects.Clear();
+            Subdivide(new Rect(0, 0, 1, 1), 0);
+        }
+
+        private void Subdivide(Rect r, int depth)
+        {
+            if (depth > 4 || r.Width < 0.05 || r.Height < 0.05)
+            {
+                _rects.Add(r);
+                return;
+            }
+
+            bool vertical = _random.NextDouble() < 0.5;
+            double split = 0.2 + _random.NextDouble() * 0.6;
+
+            if (vertical)
+            {
+                double w = r.Width * split;
+                var left = new Rect(r.X, r.Y, w, r.Height);
+                var right = new Rect(r.X + w, r.Y, r.Width - w, r.Height);
+                Subdivide(left, depth + 1);
+                Subdivide(right, depth + 1);
+            }
+            else
+            {
+                double h = r.Height * split;
+                var top = new Rect(r.X, r.Y, r.Width, h);
+                var bottom = new Rect(r.X, r.Y + h, r.Width, r.Height - h);
+                Subdivide(top, depth + 1);
+                Subdivide(bottom, depth + 1);
+            }
+        }
+
+        public void Render(DrawingContext context, Rect bounds)
+        {
+            foreach (var r in _rects)
+            {
+                var rect = new Rect(
+                    bounds.X + r.X * bounds.Width,
+                    bounds.Y + r.Y * bounds.Height,
+                    r.Width * bounds.Width,
+                    r.Height * bounds.Height);
+                var brush = _palette[_random.Next(_palette.Length)];
+                context.FillRectangle(brush, rect);
+            }
+        }
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/IScreenSaverModule.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/IScreenSaverModule.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Media;
+
+namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
+{
+    internal interface IScreenSaverModule
+    {
+        string Name { get; }
+        void Update();
+        void Render(DrawingContext context, Rect bounds);
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/RandomLinesAnimation.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/RandomLinesAnimation.cs
@@ -1,0 +1,34 @@
+using System;
+using Avalonia;
+using Avalonia.Media;
+
+namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
+{
+    internal class RandomLinesAnimation : IScreenSaverModule
+    {
+        private readonly Random _random = new();
+        public string Name => "RandomLines";
+
+        public void Update()
+        {
+            // Stateless animation; nothing to update
+        }
+
+        public void Render(DrawingContext context, Rect bounds)
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                var p1 = new Point(bounds.X + _random.NextDouble() * bounds.Width,
+                                   bounds.Y + _random.NextDouble() * bounds.Height);
+                var p2 = new Point(bounds.X + _random.NextDouble() * bounds.Width,
+                                   bounds.Y + _random.NextDouble() * bounds.Height);
+                var color = Color.FromArgb(255,
+                    (byte)_random.Next(256),
+                    (byte)_random.Next(256),
+                    (byte)_random.Next(256));
+                var pen = new Pen(new SolidColorBrush(color), 1);
+                context.DrawLine(pen, p1, p2);
+            }
+        }
+    }
+}

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/ScreenSaverModuleRegistry.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/ScreenSaverModuleRegistry.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
+{
+    internal static class ScreenSaverModuleRegistry
+    {
+        private static readonly Lazy<Dictionary<string, Type>> _modules = new(() =>
+            Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(t => typeof(IScreenSaverModule).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
+                .Select(t => (IScreenSaverModule)Activator.CreateInstance(t)!)
+                .ToDictionary(m => m.Name, m => m.GetType(), StringComparer.OrdinalIgnoreCase));
+
+        public static IReadOnlyCollection<string> ModuleNames => _modules.Value.Keys;
+
+        public static IScreenSaverModule Create(string name)
+        {
+            if (!_modules.Value.TryGetValue(name, out var type))
+            {
+                type = _modules.Value.Values.First();
+            }
+            return (IScreenSaverModule)Activator.CreateInstance(type)!;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce IScreenSaverModule interface and reflection-based registry for automatic module discovery
- refactor ScreenSaverPlugin to instantiate modules dynamically without manual enum updates
- add BouncingBall and RandomLines demo modules and adapt Deco to the new interface

## Testing
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6891fdbb97748332af1335b6e1efe2fa