### PR TITLE
Fix screensaver compile errors

### DIFF
--- a/Cycloside/Plugins/BuiltIn/ScreenSaverModules/DecoAnimation.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverModules/DecoAnimation.cs
@@ -10,7 +10,6 @@ using Avalonia.Media;
 namespace Cycloside.Plugins.BuiltIn.ScreenSaverModules
 {
     internal class DecoAnimation : IScreenSaverModule
-    internal class DecoAnimation : IScreenSaverAnimation
     {
         private readonly Random _random = new();
         private readonly List<Rect> _rects = new();

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverPlugin.cs
@@ -195,7 +195,6 @@ namespace Cycloside.Plugins.BuiltIn
 
     #region ScreenSaver Window and Control
 
-    public enum ScreenSaverType { FlowerBox, WindowsLogo, Twist, Text, Starfield, Deco }
     internal class ScreenSaverWindow : Window
     {
         public ScreenSaverWindow(IScreenSaverModule module)
@@ -226,16 +225,6 @@ namespace Cycloside.Plugins.BuiltIn
             try
             {
                 _module = module;
-                _animation = type switch
-                {
-                    ScreenSaverType.WindowsLogo => new WindowsLogoAnimation(),
-                    ScreenSaverType.Twist => new LemniscateAnimation(),
-                    ScreenSaverType.Text => new TextAnimation(),
-                    ScreenSaverType.Starfield => new StarFieldAnimation(),
-                    ScreenSaverType.Deco => new DecoAnimation(),
-                    _ => new FlowerBoxAnimation()
-                };
-
                 _renderTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(16), DispatcherPriority.Normal, OnTick);
                 _renderTimer.Start();
             }


### PR DESCRIPTION
## Summary
- remove duplicate DecoAnimation class declaration
- simplify ScreenSaverControl setup to use provided module directly

## Testing
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68929dbb925c8332b6a9401ddd96ebd9