### PR TITLE
chore: format Cycloside codebase

### DIFF
--- a/Cycloside/App.axaml.cs
+++ b/Cycloside/App.axaml.cs
@@ -70,11 +70,11 @@ public partial class App : Application
 
         base.OnFrameworkInitializationCompleted();
     }
-    
+
     private MainWindow CreateMainWindow(AppSettings settings)
     {
         _pluginManager = new PluginManager(Path.Combine(AppContext.BaseDirectory, "Plugins"), Services.NotificationCenter.Notify);
-        
+
         // Subscribe to plugin reloads to update the UI when plugins are refreshed.
         _pluginManager.PluginsReloaded += OnPluginsReloaded;
 
@@ -93,7 +93,7 @@ public partial class App : Application
 
 
         viewModel.ExitCommand = new ServicesRelayCommand(() => Shutdown());
-        
+
         // Toggle plugin enablement from the main window.
         viewModel.StartPluginCommand = new ServicesRelayCommand(pluginObj =>
         {
@@ -171,7 +171,7 @@ public partial class App : Application
         WorkspaceProfiles.Apply(settings.ActiveProfile, _pluginManager);
         RestoreSessionState(viewModel);
         RegisterHotkeys(_pluginManager);
-        
+
         _trayIcon = new TrayIcon
         {
             Icon = CreateTrayIcon(),
@@ -185,10 +185,10 @@ public partial class App : Application
             icons.Add(_trayIcon);
         }
         _trayIcon.IsVisible = true;
-        
+
         return mainWindow;
     }
-    
+
     // Handle the PluginsReloaded event to refresh menus and view models.
     private void OnPluginsReloaded()
     {
@@ -323,7 +323,7 @@ public partial class App : Application
     }
 
     #region Tray Menu and Icon Logic
-    
+
     private NativeMenu BuildTrayMenu(PluginManager manager, VolatilePluginManager volatileManager, AppSettings settings)
     {
         var pluginsMenu = new NativeMenuItem("Plugins") { Menu = new NativeMenu() };
@@ -347,7 +347,7 @@ public partial class App : Application
         var inlineItem = new NativeMenuItem("Run Inline...");
         inlineItem.Click += (_, _) => new VolatileRunnerWindow(volatileManager).Show();
         volatileMenu.Menu!.Items.Add(inlineItem);
-        
+
         // **NEW: A dedicated menu for log actions**
         var logsMenu = new NativeMenuItem("Logs") { Menu = new NativeMenu() };
         var viewErrorsItem = new NativeMenuItem("View Errors");
@@ -379,7 +379,7 @@ public partial class App : Application
                 pluginsMenu,
                 volatileMenu,
                 new NativeMenuItem("Open Plugins Folder") { Command = new ServicesRelayCommand(() => {
-                    try { Process.Start(new ProcessStartInfo { FileName = manager.PluginDirectory, UseShellExecute = true }); } 
+                    try { Process.Start(new ProcessStartInfo { FileName = manager.PluginDirectory, UseShellExecute = true }); }
                     catch (Exception ex) { Logger.Log($"Failed to open plugin folder: {ex.Message}"); }
                 })},
                 new NativeMenuItemSeparator(),
@@ -387,7 +387,7 @@ public partial class App : Application
             }
         };
     }
-    
+
     private NativeMenuItem BuildPluginMenuItem(IPlugin plugin, PluginManager manager, AppSettings settings)
     {
         var status = manager.GetStatus(plugin);
@@ -407,7 +407,7 @@ public partial class App : Application
         menuItem.Command = new ServicesRelayCommand(o =>
         {
             if (o is not NativeMenuItem item) return;
-            
+
             bool shouldBeEnabled = !manager.IsEnabled(plugin);
             if (shouldBeEnabled)
             {
@@ -483,9 +483,9 @@ public partial class App : Application
                 if (icon != null)
                 {
                     using var stream = new MemoryStream();
-                    #pragma warning disable CA1416
+#pragma warning disable CA1416
                     icon.Save(stream);
-                    #pragma warning restore CA1416
+#pragma warning restore CA1416
                     stream.Position = 0;
                     return new WindowIcon(stream);
                 }
@@ -516,6 +516,6 @@ public partial class App : Application
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool DestroyIcon(IntPtr handle);
-    
+
     #endregion
 }

--- a/Cycloside/Effects/TransparencyEffect.cs
+++ b/Cycloside/Effects/TransparencyEffect.cs
@@ -36,7 +36,7 @@ public class TransparencyEffect : IWindowEffect
         {
             Duration = TimeSpan.FromMilliseconds(200),
             Easing = new QuadraticEaseOut(),
-            Children = { new KeyFrame{ Cue = new Cue(1d), Setters = { new Setter(Window.OpacityProperty, value) } } }
+            Children = { new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(Window.OpacityProperty, value) } } }
         };
         anim.RunAsync(win);
     }

--- a/Cycloside/PluginBus.cs
+++ b/Cycloside/PluginBus.cs
@@ -10,7 +10,7 @@ namespace Cycloside;
 /// </summary>
 public static class PluginBus
 {
-    private static readonly Dictionary<string,List<Action<object?>>> _subs = new();
+    private static readonly Dictionary<string, List<Action<object?>>> _subs = new();
 
     /// <summary>
     /// Subscribe to a specific topic.
@@ -19,9 +19,9 @@ public static class PluginBus
     /// <param name="handler">Callback invoked with the published payload.</param>
     public static void Subscribe(string topic, Action<object?> handler)
     {
-        lock(_subs)
+        lock (_subs)
         {
-            if(!_subs.TryGetValue(topic, out var list))
+            if (!_subs.TryGetValue(topic, out var list))
             {
                 list = new();
                 _subs[topic] = list;
@@ -35,12 +35,12 @@ public static class PluginBus
     /// </summary>
     public static void Unsubscribe(string topic, Action<object?> handler)
     {
-        lock(_subs)
+        lock (_subs)
         {
-            if(_subs.TryGetValue(topic, out var list))
+            if (_subs.TryGetValue(topic, out var list))
             {
                 list.RemoveAll(h => h == handler);
-                if(list.Count == 0)
+                if (list.Count == 0)
                     _subs.Remove(topic);
             }
         }
@@ -52,12 +52,12 @@ public static class PluginBus
     public static void Publish(string topic, object? payload = null)
     {
         List<Action<object?>>? list = null;
-        lock(_subs)
+        lock (_subs)
             _subs.TryGetValue(topic, out list);
-        if(list == null) return;
-        foreach(var h in list.ToArray())
+        if (list == null) return;
+        foreach (var h in list.ToArray())
         {
-            try { h(payload); } catch(Exception ex) { Logger.Log($"Bus handler error: {ex.Message}"); }
+            try { h(payload); } catch (Exception ex) { Logger.Log($"Bus handler error: {ex.Message}"); }
         }
     }
 }

--- a/Cycloside/PluginDevWizard.cs
+++ b/Cycloside/PluginDevWizard.cs
@@ -33,7 +33,7 @@ public class PluginDevWizard : Window
         _typeBox.Items.Add("Lua volatile");
         _typeBox.Items.Add("C# volatile");
 
-        var create = new Button { Content = "Create", Margin = new Thickness(0,10,0,0) };
+        var create = new Button { Content = "Create", Margin = new Thickness(0, 10, 0, 0) };
         create.Click += Create_Click;
         panel.Children.Add(_nameBox);
         panel.Children.Add(_typeBox);

--- a/Cycloside/PluginSettingsWindow.axaml.cs
+++ b/Cycloside/PluginSettingsWindow.axaml.cs
@@ -67,10 +67,10 @@ public partial class PluginSettingsWindow : Window
         var newPlugins = _manager.Plugins.Where(p => _manager.GetStatus(p) != Plugins.PluginChangeStatus.None).ToList();
         if (newPlugins.Count > 0)
         {
-            panel.Children.Add(new TextBlock { Text = "New or Updated", FontWeight = FontWeight.Bold, Margin = new Thickness(0,0,0,4) });
+            panel.Children.Add(new TextBlock { Text = "New or Updated", FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 4) });
             foreach (var p in newPlugins)
                 AddPluginItem(p);
-            panel.Children.Add(new Separator { Margin = new Thickness(0,4,0,4) });
+            panel.Children.Add(new Separator { Margin = new Thickness(0, 4, 0, 4) });
         }
 
         foreach (var plugin in _manager.Plugins.Except(newPlugins))

--- a/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/CodeEditorPlugin.cs
@@ -140,13 +140,13 @@ namespace Cycloside.Plugins.BuiltIn
             if (_editor == null || _outputBox == null) return;
             var code = _editor.Text ?? string.Empty;
             var lang = GetSelectedLanguage();
-            
+
             if (string.IsNullOrWhiteSpace(code))
             {
                 _outputBox.Text = "No code to run. Please enter some code first.";
                 return;
             }
-            
+
             try
             {
                 _outputBox.Text = "Running code...\r\n";
@@ -177,19 +177,19 @@ namespace Cycloside.Plugins.BuiltIn
                         _outputBox.Text = csWriter.ToString() + (csResult != null ? csResult.ToString() : string.Empty);
                         break;
                     case "Python":
-                    {
-                        var engine = Python.CreateEngine();
-                        using var stream = new MemoryStream();
-                        engine.Runtime.IO.SetOutput(stream, Encoding.UTF8);
-                        engine.Runtime.IO.SetErrorOutput(stream, Encoding.UTF8);
-                        var scope = engine.CreateScope();
-                        var source = engine.CreateScriptSourceFromString(code);
-                        var pyResult = source.Execute(scope);
-                        stream.Position = 0;
-                        var output = new StreamReader(stream).ReadToEnd();
-                        _outputBox.Text = output + (pyResult != null ? pyResult.ToString() : string.Empty);
-                        break;
-                    }
+                        {
+                            var engine = Python.CreateEngine();
+                            using var stream = new MemoryStream();
+                            engine.Runtime.IO.SetOutput(stream, Encoding.UTF8);
+                            engine.Runtime.IO.SetErrorOutput(stream, Encoding.UTF8);
+                            var scope = engine.CreateScope();
+                            var source = engine.CreateScriptSourceFromString(code);
+                            var pyResult = source.Execute(scope);
+                            stream.Position = 0;
+                            var output = new StreamReader(stream).ReadToEnd();
+                            _outputBox.Text = output + (pyResult != null ? pyResult.ToString() : string.Empty);
+                            break;
+                        }
                     case "JavaScript":
                         var sb = new StringBuilder();
                         var jsEngine = new Engine();

--- a/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DateTimeOverlayPlugin.cs
@@ -12,7 +12,7 @@ namespace Cycloside.Plugins.BuiltIn
         // --- Fields ---
         private DateTimeOverlayWindow? _window;
         private DispatcherTimer? _timer;
-        
+
         // --- Configuration for new features ---
         private readonly List<string> _formats = new() { "G", "g", "yyyy-MM-dd HH:mm:ss", "T", "t" };
         private int _currentFormatIndex = 0;
@@ -37,10 +37,10 @@ namespace Cycloside.Plugins.BuiltIn
             _window = new DateTimeOverlayWindow { DataContext = this };
             ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DateTimeOverlayPlugin));
-            
+
             // Set up the timer
-            _timer = new DispatcherTimer(TimeSpan.FromSeconds(1), DispatcherPriority.Background, (_,_) => UpdateTime());
-            
+            _timer = new DispatcherTimer(TimeSpan.FromSeconds(1), DispatcherPriority.Background, (_, _) => UpdateTime());
+
             UpdateTime(); // Update immediately on start
             _timer.Start();
             _window.Show();

--- a/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/DiskUsagePlugin.cs
@@ -36,7 +36,7 @@ namespace Cycloside.Plugins.BuiltIn
                 _selectFolderButton.Click += async (_, _) => await SelectAndLoadDirectoryAsync();
 
             // Apply theming and effects (assuming these are valid managers in your project)
-            
+
             ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, nameof(DiskUsagePlugin));
 

--- a/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/EnvironmentEditorPlugin.cs
@@ -75,20 +75,20 @@ namespace Cycloside.Plugins.BuiltIn
         private void LoadVariables()
         {
             var target = _currentTarget;
-            
+
             _items.Clear();
             try
             {
                 var variables = Environment.GetEnvironmentVariables(target);
                 var variableList = new List<EnvItem>();
-                
+
                 foreach (DictionaryEntry de in variables)
                 {
                     if (de.Key != null)
                     {
                         var key = de.Key.ToString()!;
                         var value = de.Value?.ToString() ?? string.Empty;
-                        
+
                         // FIXED: Add some common environment variables that should always be visible
                         if (target == EnvironmentVariableTarget.Process)
                         {
@@ -114,19 +114,19 @@ namespace Cycloside.Plugins.BuiltIn
                                 variableList.Add(new EnvItem { Key = "COMPUTERNAME", Value = Environment.GetEnvironmentVariable("COMPUTERNAME") ?? "" });
                             }
                         }
-                        
+
                         variableList.Add(new EnvItem { Key = key, Value = value });
                     }
                 }
-                
+
                 // Sort variables alphabetically for better organization
                 variableList = variableList.OrderBy(v => v.Key).ToList();
-                
+
                 foreach (var item in variableList)
                 {
                     _items.Add(item);
                 }
-                
+
                 Logger.Log($"Environment Editor: Loaded {_items.Count} variables for {target} scope");
             }
             catch (Exception ex)
@@ -136,7 +136,7 @@ namespace Cycloside.Plugins.BuiltIn
                 Logger.Log($"Environment Editor: Failed to load variables for {target} scope: {ex.Message}");
             }
         }
-        
+
         private void SaveVariables()
         {
             var target = _currentTarget;
@@ -156,15 +156,15 @@ namespace Cycloside.Plugins.BuiltIn
                 {
                     Environment.SetEnvironmentVariable(key, null, target);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                     _items.Add(new EnvItem { Key = "ERROR", Value = $"Could not remove '{key}': {ex.Message}" });
+                    _items.Add(new EnvItem { Key = "ERROR", Value = $"Could not remove '{key}': {ex.Message}" });
                 }
             }
 
             foreach (var item in _items)
             {
-                if(string.IsNullOrWhiteSpace(item.Key)) continue;
+                if (string.IsNullOrWhiteSpace(item.Key)) continue;
 
                 try
                 {
@@ -175,7 +175,7 @@ namespace Cycloside.Plugins.BuiltIn
                     _items.Add(new EnvItem { Key = "ERROR", Value = $"Could not save '{item.Key}': {ex.Message}" });
                 }
             }
-            
+
             LoadVariables();
         }
 

--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -254,10 +254,10 @@ Tips:
             var dx = end.X - start.X;
             var dy = end.Y - start.Y;
             var length = Math.Sqrt(dx * dx + dy * dy);
-            
+
             if (length == 0) return false;
 
-            var t = Math.Max(0, Math.Min(1, 
+            var t = Math.Max(0, Math.Min(1,
                 ((ball.Position.X - start.X) * dx + (ball.Position.Y - start.Y) * dy) / (length * length)));
 
             var closest = new Point(start.X + t * dx, start.Y + t * dy);
@@ -403,7 +403,7 @@ Tips:
         {
             Lives--;
             JezzballSound.Play(JezzballSoundEvent.WallHit);
-            
+
             if (Lives <= 0)
             {
                 RoundState = "lost";
@@ -480,7 +480,7 @@ Tips:
                 var gridX = (int)(ball.Position.X / _gridSize);
                 var gridY = (int)(ball.Position.Y / _gridSize);
                 var cellIndex = gridY * (int)(_gameSize.Width / _gridSize) + gridX;
-                
+
                 if (cellIndex >= 0 && cellIndex < _grid.Count && !_grid[cellIndex].Scored)
                 {
                     return true;
@@ -624,7 +624,7 @@ Tips:
             if (_gameState.RoundState != "running") return;
 
             var position = e.GetPosition(sender as Control);
-            
+
             if (e.GetCurrentPoint(sender as Control).Properties.IsRightButtonPressed)
             {
                 // Right click changes direction
@@ -675,12 +675,12 @@ Tips:
             {
                 var gridSize = 20.0;
                 var pen = new Pen(Brushes.DarkGray, 1);
-                
+
                 for (double x = 0; x < bounds.Width; x += gridSize)
                 {
                     context.DrawLine(pen, new Point(x, 0), new Point(x, bounds.Height));
                 }
-                
+
                 for (double y = 0; y < bounds.Height; y += gridSize)
                 {
                     context.DrawLine(pen, new Point(0, y), new Point(bounds.Width, y));

--- a/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/LogViewerPlugin.cs
@@ -25,19 +25,19 @@ namespace Cycloside.Plugins.BuiltIn
         private string _currentFilter = string.Empty;
         private string _severityFilter = "All";
         private ComboBox? _severityBox;
-        private readonly Dictionary<string,long> _filePositions = new();
+        private readonly Dictionary<string, long> _filePositions = new();
 
         private readonly SemaphoreSlim _fileReadLock = new SemaphoreSlim(1, 1);
 
         // --- NEW: A property to hold a filter term on startup ---
         public string InitialFilter { get; set; } = string.Empty;
-        
+
         public string Name => "Log Viewer";
         public string Description => "Tail and filter log files in real-time. Now with auto-loading and saving!";
         public Version Version => new Version(0, 6, 0); // Incremented for new features
         public Widgets.IWidget? Widget => null;
         public bool ForceDefaultTheme => false;
-        
+
         private string GetLogDirectory()
         {
             if (OperatingSystem.IsWindows())
@@ -58,7 +58,7 @@ namespace Cycloside.Plugins.BuiltIn
             var openButton = new Button { Content = "Open Log File" };
             openButton.Click += async (s, e) => await SelectAndLoadFileAsync();
 
-            var saveButton = new Button { Content = "Save Log As...", Margin = new Avalonia.Thickness(5,0) };
+            var saveButton = new Button { Content = "Save Log As...", Margin = new Avalonia.Thickness(5, 0) };
             saveButton.Click += async (s, e) => await SaveLogAsync();
 
             var filterBox = _window.FindControl<TextBox>("FilterBox");
@@ -134,7 +134,7 @@ namespace Cycloside.Plugins.BuiltIn
             _window.Show();
             Dispatcher.UIThread.InvokeAsync(AttemptToLoadDefaultLogAsync);
         }
-        
+
         private void OnLogBoxTextChanged(object? sender, TextChangedEventArgs e)
         {
             if (_autoScrollCheck?.IsChecked == true && _logBox != null)
@@ -142,7 +142,7 @@ namespace Cycloside.Plugins.BuiltIn
                 _logBox.CaretIndex = _logBox.Text?.Length ?? 0;
             }
         }
-        
+
         private async Task AttemptToLoadDefaultLogAsync()
         {
             var logDir = GetLogDirectory();
@@ -197,7 +197,7 @@ namespace Cycloside.Plugins.BuiltIn
                 FileTypeChoices = new[] { new FilePickerFileType("Text File") { Patterns = new[] { "*.txt" } } },
                 SuggestedStartLocation = start
             });
-            
+
             if (file?.Path.LocalPath != null)
             {
                 try

--- a/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MP3PlayerPlugin.cs
@@ -77,10 +77,10 @@ namespace Cycloside.Plugins.BuiltIn
                 // Scale the dB value (e.g., -90dB to 0dB) to a byte (0-255)
                 double scaledValue = (90 + decibels) * (255.0 / 90.0);
                 byte finalValue = (byte)Math.Max(0, Math.Min(255, scaledValue));
-                
+
                 // For stereo visualizations, copy the value to both left and right channels
                 fftData[i] = finalValue;
-                if(i + fftData.Length / 2 < fftData.Length)
+                if (i + fftData.Length / 2 < fftData.Length)
                     fftData[i + fftData.Length / 2] = finalValue;
             }
         }
@@ -126,12 +126,12 @@ namespace Cycloside.Plugins.BuiltIn
         // --- Observable Properties ---
         public ObservableCollection<string> Playlist { get; } = new();
         [ObservableProperty] private string? _currentTrackName;
-        [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsStopped))] private bool _isPlaying;
+        [ObservableProperty][NotifyPropertyChangedFor(nameof(IsStopped))] private bool _isPlaying;
         public bool IsStopped => !IsPlaying;
         [ObservableProperty] private TimeSpan _currentTime;
         [ObservableProperty] private TimeSpan _totalTime;
         [ObservableProperty] private string? _errorMessage;
-        [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ToggleMuteCommand))] private float _volume = 1.0f;
+        [ObservableProperty][NotifyCanExecuteChangedFor(nameof(ToggleMuteCommand))] private float _volume = 1.0f;
         [ObservableProperty] private bool _isMuted;
         [ObservableProperty] private string _visualizationStatus = "Disabled";
 
@@ -238,7 +238,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 // FIXED: Try multiple approaches to find the WinampVisHostPlugin
                 if (_visHost != null) return; // Already found
-                
+
                 // Approach 1: Try to find through the applications plugin manager
                 if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
                     desktop.MainWindow is MainWindow mainWindow &&
@@ -253,7 +253,7 @@ namespace Cycloside.Plugins.BuiltIn
                         return;
                     }
                 }
-                
+
                 // Approach 2: Try to create a new instance if not found
                 Logger.Log("Winamp Visual Host plugin not found, attempting to create new instance");
                 _visHost = new WinampVisHostPlugin();
@@ -290,7 +290,8 @@ namespace Cycloside.Plugins.BuiltIn
             var start = await DialogHelper.GetDefaultStartLocationAsync(topLevel.StorageProvider);
             var openResult = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
-                Title = "Select MP3 Files", AllowMultiple = true,
+                Title = "Select MP3 Files",
+                AllowMultiple = true,
                 FileTypeFilter = new[] { new FilePickerFileType("MP3 Files") { Patterns = new[] { "*.mp3" } } },
                 SuggestedStartLocation = start
             });
@@ -382,7 +383,7 @@ namespace Cycloside.Plugins.BuiltIn
             try
             {
                 _audioReader = new AudioFileReader(filePath);
-                
+
                 // Use a SampleAggregator to properly handle audio samples for FFT.
                 var aggregator = new SampleAggregator(_audioReader);
                 _spectrumAnalyzer = new SpectrumAnalyzer(aggregator, 1024);
@@ -474,7 +475,7 @@ namespace Cycloside.Plugins.BuiltIn
         {
             if (value) _progressTimer.Start();
             else _progressTimer.Stop();
-            
+
             PlayCommand.NotifyCanExecuteChanged();
             PauseCommand.NotifyCanExecuteChanged();
             StopPlaybackCommand.NotifyCanExecuteChanged();

--- a/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/MacroPlugin.cs
@@ -41,7 +41,7 @@ public class MacroPlugin : IPlugin
     private IGlobalHook? _hook;
     private readonly IEventSimulator _simulator = new EventSimulator();
     private readonly bool _isWindows = OperatingSystem.IsWindows();
-    
+
     // --- Recording Data Fields ---
     private readonly List<MacroEvent> _events = new();
     private Stopwatch? _timer;
@@ -115,8 +115,8 @@ public class MacroPlugin : IPlugin
         _hook.RunAsync();
 
         SetStatus("Recording...");
-        if(_recordButton != null) _recordButton.IsEnabled = false;
-        if(_stopButton != null) _stopButton.IsEnabled = true;
+        if (_recordButton != null) _recordButton.IsEnabled = false;
+        if (_stopButton != null) _stopButton.IsEnabled = true;
     }
 
     private void StopRecording()
@@ -138,9 +138,9 @@ public class MacroPlugin : IPlugin
         {
             SetStatus("Recording stopped. No name provided or no events recorded.");
         }
-        
-        if(_recordButton != null) _recordButton.IsEnabled = true;
-        if(_stopButton != null) _stopButton.IsEnabled = false;
+
+        if (_recordButton != null) _recordButton.IsEnabled = true;
+        if (_stopButton != null) _stopButton.IsEnabled = false;
     }
 
     private void OnKeyPressed(object? sender, KeyboardHookEventArgs e) => AddEvent(true, e.Data.KeyCode);
@@ -198,7 +198,7 @@ public class MacroPlugin : IPlugin
             {
                 await Task.Delay(ev.Delay);
             }
-            
+
             if (ev.IsPress)
                 _simulator.SimulateKeyPress(ev.Code);
             else
@@ -213,7 +213,7 @@ public class MacroPlugin : IPlugin
     private void DeleteSelected()
     {
         if (_macroList?.SelectedItem is not string selectedName) return;
-        
+
         var macro = MacroManager.Macros.FirstOrDefault(m => m.Name == selectedName);
         if (macro != null)
         {

--- a/Cycloside/Plugins/BuiltIn/ModTrackerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ModTrackerPlugin.cs
@@ -49,7 +49,7 @@ namespace Cycloside.Plugins.BuiltIn
         /// </remarks>
         public Module UnsafeGetModule() => _module;
 
-        
+
         public void Dispose()
         {
             _module.Dispose();
@@ -64,14 +64,14 @@ namespace Cycloside.Plugins.BuiltIn
         private IWavePlayer? _wavePlayer;
         private OpenMptWaveProvider? _waveProvider;
         private readonly DispatcherTimer _uiTimer;
-        
+
         // --- IPlugin Properties ---
         public string Name => "ModPlug Tracker";
         public string Description => "Plays and inspects various tracker module files (MOD, IT, S3M, XM, etc.).";
         public Version Version => new(1, 0, 0);
         public Widgets.IWidget? Widget => null;
         public bool ForceDefaultTheme => false;
-        
+
         // --- Observable Properties for UI Binding ---
         [ObservableProperty]
         private string _moduleName = "No file loaded.";
@@ -98,7 +98,7 @@ namespace Cycloside.Plugins.BuiltIn
                 _window.Activate();
                 return;
             }
-            
+
             _window = BuildTrackerWindow();
             ThemeManager.ApplyForPlugin(_window, this);
             WindowEffectsManager.Instance.ApplyConfiguredEffects(_window, Name);
@@ -125,7 +125,7 @@ namespace Cycloside.Plugins.BuiltIn
             _wavePlayer?.Stop();
             _wavePlayer?.Dispose();
             _wavePlayer = null;
-            
+
             _waveProvider?.Dispose();
             _waveProvider = null;
 
@@ -135,21 +135,21 @@ namespace Cycloside.Plugins.BuiltIn
         private void UpdateUI(object? sender, EventArgs e)
         {
             if (!IsPlaying || _waveProvider == null) return;
-            
+
             // This is where we poll libopenmpt for the current state and format it for display.
             var pattern = _waveProvider.UnsafeGetModule().GetCurrentPattern();
             var row = _waveProvider.UnsafeGetModule().GetCurrentRow();
             var numRows = _waveProvider.UnsafeGetModule().GetPatternRowCount(pattern);
-            
+
             var sb = new StringBuilder();
             sb.AppendLine($"Pattern: {pattern} / {_waveProvider.UnsafeGetModule().GetNumberOfPatterns() - 1} | Row: {row} / {numRows - 1}");
             sb.AppendLine("-------------------------------------------------");
-            
+
             // Display a snippet of the current pattern
             int startRow = Math.Max(0, row - 8);
             int endRow = Math.Min(numRows, row + 8);
 
-            for(int r = startRow; r < endRow; r++)
+            for (int r = startRow; r < endRow; r++)
             {
                 if (r == row) sb.Append("> "); else sb.Append("  ");
                 sb.Append($"{r:D2}: ");
@@ -162,9 +162,9 @@ namespace Cycloside.Plugins.BuiltIn
             }
             PatternData = sb.ToString();
         }
-        
+
         // --- Commands ---
-        
+
         [RelayCommand]
         private async Task OpenFile()
         {
@@ -178,13 +178,13 @@ namespace Cycloside.Plugins.BuiltIn
                 FileTypeFilter = new[] { new FilePickerFileType("Tracker Modules") { Patterns = new[] { "*.it", "*.xm", "*.s3m", "*.mod" } }, FilePickerFileTypes.All },
                 SuggestedStartLocation = start
             });
-            
+
             if (result?.FirstOrDefault()?.TryGetLocalPath() is { } path)
             {
                 LoadModule(path);
             }
         }
-        
+
         private void LoadModule(string path)
         {
             CleanupPlayback();
@@ -193,7 +193,7 @@ namespace Cycloside.Plugins.BuiltIn
                 var fileBytes = File.ReadAllBytes(path);
                 var module = Module.Create(fileBytes, new Module.Settings());
                 _waveProvider = new OpenMptWaveProvider(module);
-                
+
                 _wavePlayer = new WaveOutEvent() { DesiredLatency = 200 };
                 _wavePlayer.Init(_waveProvider);
 
@@ -202,11 +202,11 @@ namespace Cycloside.Plugins.BuiltIn
                 {
                     ModuleName = Path.GetFileName(path);
                 }
-                
+
                 ModuleInfo = $"Channels: {module.GetNumberOfChannels()} | " +
                              $"Patterns: {module.GetNumberOfPatterns()} | " +
                              $"Samples: {module.GetNumberOfSamples()}";
-                
+
                 PlayCommand.Execute(null);
             }
             catch (Exception ex)
@@ -245,13 +245,13 @@ namespace Cycloside.Plugins.BuiltIn
         }
 
         private bool CanPlay() => !IsPlaying && _waveProvider != null;
-        
+
         // --- UI Construction ---
         private Window BuildTrackerWindow()
         {
             var openButton = new Button { Content = "Open..." };
             openButton.Bind(Button.CommandProperty, new Binding(nameof(OpenFileCommand)));
-            
+
             var playButton = new Button { Content = "Play" };
             playButton.Bind(Button.CommandProperty, new Binding(nameof(PlayCommand)));
 
@@ -269,10 +269,10 @@ namespace Cycloside.Plugins.BuiltIn
                 Children = { openButton, playButton, pauseButton, stopButton }
             };
 
-            var nameBlock = new TextBlock { FontWeight = FontWeight.Bold, FontSize = 14, Margin = new Thickness(5,0) };
+            var nameBlock = new TextBlock { FontWeight = FontWeight.Bold, FontSize = 14, Margin = new Thickness(5, 0) };
             nameBlock.Bind(TextBlock.TextProperty, new Binding(nameof(ModuleName)));
 
-            var infoBlock = new TextBlock { Opacity = 0.8, Margin = new Thickness(5,0,5,5) };
+            var infoBlock = new TextBlock { Opacity = 0.8, Margin = new Thickness(5, 0, 5, 5) };
             infoBlock.Bind(TextBlock.TextProperty, new Binding(nameof(ModuleInfo)));
 
             var patternBlock = new TextBox

--- a/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/NotificationCenterPlugin.cs
@@ -16,7 +16,7 @@ public class NotificationCenterPlugin : IPlugin, IDisposable, IWorkspaceItem
     public ObservableCollection<string> Messages { get; } = new();
     public string Name => "Notification Center";
     public string Description => "View recent notifications";
-    public Version Version => new(0,1,0);
+    public Version Version => new(0, 1, 0);
     public Widgets.IWidget? Widget => null;
     public bool ForceDefaultTheme => false;
     public bool UseWorkspace { get; set; }

--- a/Cycloside/Plugins/BuiltIn/ProcessMonitorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ProcessMonitorPlugin.cs
@@ -76,7 +76,7 @@ namespace Cycloside.Plugins.BuiltIn
                             // FIXED: Better error handling and more process information
                             var memoryMB = p.WorkingSet64 / 1024 / 1024;
                             var processName = !string.IsNullOrEmpty(p.ProcessName) ? p.ProcessName : "Unknown";
-                            
+
                             // Try to get the main window title for better identification
                             string? windowTitle = null;
                             try
@@ -90,9 +90,9 @@ namespace Cycloside.Plugins.BuiltIn
                             {
                                 // Ignore errors getting window title
                             }
-                            
+
                             var displayName = !string.IsNullOrEmpty(windowTitle) ? $"{processName} - {windowTitle}" : processName;
-                            
+
                             return new ProcessInfo(displayName, memoryMB);
                         }
                         catch (Exception ex)
@@ -118,7 +118,7 @@ namespace Cycloside.Plugins.BuiltIn
                     {
                         Processes.Add(process);
                     }
-                    
+
                     // Log the update for debugging
                     Logger.Log($"Process Monitor: Updated with {currentProcesses.Count} processes");
                 });

--- a/Cycloside/Plugins/BuiltIn/ScreenSaverPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/ScreenSaverPlugin.cs
@@ -30,7 +30,7 @@ namespace Cycloside.Plugins.BuiltIn
 
         // Configuration (will be moved to settings later)
         private string _activeSaver = ScreenSaverModuleRegistry.ModuleNames.FirstOrDefault() ?? string.Empty;
-        
+
         public string Name => "ScreenSaver Host";
         public string Description => "Runs full-screen screensavers after a period of inactivity.";
         public Version Version => new(1, 4, 1); // Version bump for stability improvements
@@ -43,7 +43,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 _idleTimeout = TimeSpan.FromSeconds(60);
                 _lastInputTime = DateTime.Now;
-                
+
                 _hook = new TaskPoolGlobalHook();
                 _hook.MouseMoved += OnMouseMoved;
                 _hook.KeyPressed += OnKeyPressed;
@@ -249,7 +249,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 Cycloside.Services.Logger.Error($"Error updating animation: {ex.Message}");
                 _errorCount++;
-                
+
                 if (_errorCount >= MaxErrors)
                 {
                     Cycloside.Services.Logger.Error("Too many animation errors, stopping screensaver");
@@ -273,7 +273,7 @@ namespace Cycloside.Plugins.BuiltIn
             {
                 Cycloside.Services.Logger.Error($"Error rendering animation: {ex.Message}");
                 _errorCount++;
-                
+
                 if (_errorCount >= MaxErrors)
                 {
                     Cycloside.Services.Logger.Error("Too many rendering errors, stopping screensaver");
@@ -317,7 +317,7 @@ namespace Cycloside.Plugins.BuiltIn
 
                 foreach (var face in Faces)
                 {
-                    if (face.P0 >= Vertices.Count || face.P1 >= Vertices.Count || 
+                    if (face.P0 >= Vertices.Count || face.P1 >= Vertices.Count ||
                         face.P2 >= Vertices.Count || face.P3 >= Vertices.Count)
                     {
                         Cycloside.Services.Logger.Error("Invalid face vertex indices");
@@ -352,7 +352,7 @@ namespace Cycloside.Plugins.BuiltIn
         public int P0, P1, P2, P3;
         public int MaterialId;
     }
-    
+
     #endregion
 
     #region Animation Implementations
@@ -451,7 +451,7 @@ namespace Cycloside.Plugins.BuiltIn
         {
             mesh.Vertices.Clear();
             mesh.Faces.Clear();
-            
+
             float GetZPos(float x) => (float)(Math.Sin(wavePhase + (x * 4.0)) * 0.1);
 
             void AddPanel(float x, float y, float w, float h, int matId)
@@ -468,10 +468,10 @@ namespace Cycloside.Plugins.BuiltIn
             const float w = 0.45f;
             const float h = 0.45f;
             const float gap = 0.1f;
-            AddPanel(-w - gap/2, h + gap/2, w, h, 1); // Red (top-left)
-            AddPanel(gap/2, h + gap/2, w, h, 3);      // Green (top-right)
-            AddPanel(-w - gap/2, -h - gap/2, w, h, 2); // Blue (bottom-left)
-            AddPanel(gap/2, -h - gap/2, w, h, 4);     // Yellow (bottom-right)
+            AddPanel(-w - gap / 2, h + gap / 2, w, h, 1); // Red (top-left)
+            AddPanel(gap / 2, h + gap / 2, w, h, 3);      // Green (top-right)
+            AddPanel(-w - gap / 2, -h - gap / 2, w, h, 2); // Blue (bottom-left)
+            AddPanel(gap / 2, -h - gap / 2, w, h, 4);     // Yellow (bottom-right)
         }
     }
 
@@ -491,7 +491,7 @@ namespace Cycloside.Plugins.BuiltIn
             _mesh = new Mesh();
             GenerateLemniscate(_mesh);
         }
-        
+
         public void Update()
         {
             _mxrot += 0.2; _myrot += _myrotInc; _zrot += _zrotInc;
@@ -511,7 +511,7 @@ namespace Cycloside.Plugins.BuiltIn
                     new TranslateTransform(bounds.Width / 2, bounds.Height / 2)
                 }
             };
-            
+
             using (context.PushTransform(transform.Value))
             {
                 var geometry = new StreamGeometry();
@@ -526,7 +526,7 @@ namespace Cycloside.Plugins.BuiltIn
                 context.DrawGeometry(null, new Pen(Brushes.CornflowerBlue, 0.05), geometry);
             }
         }
-        
+
         private static void GenerateLemniscate(Mesh mesh)
         {
             mesh.Vertices.Clear();
@@ -556,7 +556,7 @@ namespace Cycloside.Plugins.BuiltIn
         {
             _textMesh = new Mesh();
             Generate3DTextGeometry(_textMesh, "Cycloside", "Arial", 1.0f, 0.2f);
-            
+
             _materials = new IBrush[] { Brushes.CornflowerBlue, Brushes.DarkSlateBlue };
         }
 
@@ -580,7 +580,7 @@ namespace Cycloside.Plugins.BuiltIn
                     new TranslateTransform(bounds.Width / 2, bounds.Height / 2)
                 }
             };
-            
+
             using (context.PushTransform(transform.Value))
             {
                 _textMesh.Draw(context, _materials);
@@ -687,7 +687,7 @@ namespace Cycloside.Plugins.BuiltIn
     }
 
     #endregion
-    
+
     #region Geometry and Helpers
 
     // A simple 3D point/vector struct for our math
@@ -701,7 +701,7 @@ namespace Cycloside.Plugins.BuiltIn
     {
         public static Point ToPoint(this Point3D p) => new(p.X, p.Y);
     }
-    
+
     internal class FlowerBoxGeometry
     {
         private readonly Point3D[] _basePoints;
@@ -724,7 +724,7 @@ namespace Cycloside.Plugins.BuiltIn
 
             _transformedPoints = new Point3D[_basePoints.Length];
             _vlen = new float[_basePoints.Length];
-            
+
             for (int i = 0; i < _basePoints.Length; i++)
             {
                 var p = _basePoints[i];
@@ -732,7 +732,7 @@ namespace Cycloside.Plugins.BuiltIn
                 d *= 2.0f;
                 _vlen[i] = (1.0f - d) / d;
             }
-            
+
             _sideColors = new IBrush[] { Brushes.Red, Brushes.Green, Brushes.Blue, Brushes.Magenta, Brushes.Cyan, Brushes.Yellow };
             UpdatePoints(0.0f);
         }

--- a/Cycloside/Plugins/BuiltIn/TaskSchedulerPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TaskSchedulerPlugin.cs
@@ -13,7 +13,7 @@ public class TaskSchedulerPlugin : IPlugin
 
     public string Name => "Task Scheduler";
     public string Description => "Schedule commands with cron or Task Scheduler";
-    public Version Version => new(0,1,0);
+    public Version Version => new(0, 1, 0);
     public Widgets.IWidget? Widget => null;
     public bool ForceDefaultTheme => false;
 

--- a/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/TextEditorPlugin.cs
@@ -37,7 +37,7 @@ namespace Cycloside.Plugins.BuiltIn
 
         [ObservableProperty]
         private string _windowTitle = "Cycloside Editor - Untitled";
-        
+
         // --- Plugin Lifecycle Methods ---
         public void Start()
         {
@@ -90,7 +90,7 @@ namespace Cycloside.Plugins.BuiltIn
         private async Task OpenFile()
         {
             if (_window is null || !await CanProceedWithUnsavedChanges()) return;
-            
+
             var start = await DialogHelper.GetDefaultStartLocationAsync(_window.StorageProvider);
             var openResult = await _window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
@@ -135,7 +135,7 @@ namespace Cycloside.Plugins.BuiltIn
         private async Task SaveFileAs()
         {
             if (_window is null) return;
-            
+
             var start = await DialogHelper.GetDefaultStartLocationAsync(_window.StorageProvider);
             var saveResult = await _window.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
@@ -173,7 +173,7 @@ namespace Cycloside.Plugins.BuiltIn
         private async Task<bool> CanProceedWithUnsavedChanges()
         {
             if (_window is null || EditorContent == _lastSavedText) return true;
-            
+
             var confirm = new ConfirmationWindow("Unsaved Changes", "Discard unsaved changes?");
             return await confirm.ShowDialog<bool>(_window);
         }

--- a/Cycloside/Plugins/BuiltIn/WidgetHostPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WidgetHostPlugin.cs
@@ -26,7 +26,7 @@ public class WidgetHostPlugin : IPlugin
 
     public string Name => "Widget Host";
     public string Description => "Hosts movable desktop widgets";
-    public Version Version => new(0,1,0);
+    public Version Version => new(0, 1, 0);
     public Widgets.IWidget? Widget => null;
     public bool ForceDefaultTheme => false;
 

--- a/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
@@ -13,7 +13,7 @@ public class WinampVisHostPlugin : IPlugin
 
     public string Name => "Winamp Visual Host";
     public string Description => "Hosts Winamp visualization plugins";
-    public Version Version => new(0,1,0);
+    public Version Version => new(0, 1, 0);
     public Widgets.IWidget? Widget => null; // For UI widget host support
     public bool ForceDefaultTheme => false;
 
@@ -23,7 +23,7 @@ public class WinampVisHostPlugin : IPlugin
     {
         // Don't auto-start - wait for MP3layer to enable it
         Logger.Log("Winamp Visual Host started - waiting for MP3able visualization");
-        
+
         // FIXED: Create the host window but don't show it yet
         _hostWindow = new VisHostWindow();
         ThemeManager.ApplyForPlugin(_hostWindow, this);
@@ -98,14 +98,14 @@ public class WinampVisHostPlugin : IPlugin
         {
             _manager?.StopPlugin();
             _isEnabled = false;
-            
+
             // FIXED: Hide the host window when visualization is disabled
             if (_hostWindow != null)
             {
                 _hostWindow.Hide();
                 Logger.Log("Winamp Visual Host window hidden");
             }
-            
+
             Logger.Log("Winamp Visual Host disabled");
         }
         catch (Exception ex)

--- a/Cycloside/Plugins/PluginManager.cs
+++ b/Cycloside/Plugins/PluginManager.cs
@@ -37,7 +37,7 @@ namespace Cycloside.Plugins
             }
         }
     }
-    
+
     public class PluginManager
     {
         // FIX: The core data structure is now a list of PluginInfo objects.
@@ -142,7 +142,7 @@ namespace Cycloside.Plugins
                 }
             }
         }
-        
+
         /// <summary>
         /// The new, correct implementation for hot-reloading plugins.
         /// </summary>
@@ -154,7 +154,7 @@ namespace Cycloside.Plugins
 
                 // Clear internal state
                 _pluginInfos.Clear();
-                
+
                 // It's crucial to force garbage collection here to finalize the unloading process.
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
@@ -182,7 +182,7 @@ namespace Cycloside.Plugins
                 {
                     DisablePlugin(info.Instance);
                 }
-                
+
                 // This is the critical new step: Unload the contexts.
                 foreach (var info in _pluginInfos.Where(p => p.LoadContext != null))
                 {
@@ -201,9 +201,9 @@ namespace Cycloside.Plugins
             lock (_pluginLock)
             {
                 if (_pluginInfos.Any(p => p.Instance.Name == plugin.Name)) return; // Don't add duplicates
-                
+
                 var info = new PluginInfo(plugin); // Built-in plugins have no context or path.
-                
+
                 var versions = SettingsManager.Settings.PluginVersions;
                 if (!versions.TryGetValue(plugin.Name, out var ver))
                 {
@@ -246,7 +246,7 @@ namespace Cycloside.Plugins
                 AddPlugin(factory());
             }
         }
-        
+
         private PluginInfo? GetInfo(IPlugin plugin) => _pluginInfos.FirstOrDefault(p => p.Instance == plugin);
 
         public void EnablePlugin(IPlugin plugin)

--- a/Cycloside/ProfileEditorWindow.axaml.cs
+++ b/Cycloside/ProfileEditorWindow.axaml.cs
@@ -284,7 +284,7 @@ namespace Cycloside
 
             var buttonPanel = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center };
             buttonPanel.Children.Add(yesButton);
-buttonPanel.Children.Add(noButton);
+            buttonPanel.Children.Add(noButton);
 
             var mainPanel = new StackPanel { Spacing = 10 };
             mainPanel.Children.Add(messageBlock);

--- a/Cycloside/SDK/Examples/ExamplePlugin.cs
+++ b/Cycloside/SDK/Examples/ExamplePlugin.cs
@@ -5,7 +5,7 @@ public class ExamplePlugin : IPlugin
 {
     public string Name => "Example";
     public string Description => "Example plugin";
-    public Version Version => new(1,0,0);
+    public Version Version => new(1, 0, 0);
     public Cycloside.Widgets.IWidget? Widget => null;
     public bool ForceDefaultTheme => false;
     public void Start() { }

--- a/Cycloside/Services/Logger.cs
+++ b/Cycloside/Services/Logger.cs
@@ -78,4 +78,4 @@ namespace Cycloside.Services
             }
         }
     }
-} 
+}

--- a/Cycloside/Services/ThemeManager.cs
+++ b/Cycloside/Services/ThemeManager.cs
@@ -33,7 +33,7 @@ namespace Cycloside.Services
             {
                 themeName = "MintGreen"; // A safe default
             }
-            
+
             if (!LoadGlobalTheme(themeName) && themeName != "MintGreen")
             {
                 LoadGlobalTheme("MintGreen"); // Fallback on failure
@@ -46,7 +46,7 @@ namespace Cycloside.Services
         /// </summary>
         public static bool LoadGlobalTheme(string themeName)
         {
-            if (Application.Current == null) 
+            if (Application.Current == null)
             {
                 Logger.Log("ThemeManager: Application.Current is null, cannot load theme");
                 return false;

--- a/Cycloside/SkinThemeEditorWindow.axaml.cs
+++ b/Cycloside/SkinThemeEditorWindow.axaml.cs
@@ -15,7 +15,7 @@ public partial class SkinThemeEditorWindow : Window
 {
     private ComboBox? _fileBox;
     private TextEditor? _editor;
-    
+
     // FIX: The path now correctly points to the "Global" subdirectory where themes are stored.
     private string _themeDir = Path.Combine(AppContext.BaseDirectory, "Themes", "Global");
 
@@ -24,10 +24,10 @@ public partial class SkinThemeEditorWindow : Window
         InitializeComponent();
         CursorManager.ApplyFromSettings(this, "Plugins");
         WindowEffectsManager.Instance.ApplyConfiguredEffects(this, nameof(SkinThemeEditorWindow));
-        
+
         _fileBox = this.FindControl<ComboBox>("FileBox");
         _editor = this.FindControl<TextEditor>("Editor");
-        
+
         if (_editor != null)
         {
             _editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("XML");
@@ -49,7 +49,7 @@ public partial class SkinThemeEditorWindow : Window
         if (!Directory.Exists(_themeDir))
         {
             // If the directory doesn't exist, create it. This prevents a crash on first run.
-            try 
+            try
             {
                 Directory.CreateDirectory(_themeDir);
             }

--- a/Cycloside/ThemeSettingsWindow.axaml.cs
+++ b/Cycloside/ThemeSettingsWindow.axaml.cs
@@ -16,7 +16,7 @@ public partial class ThemeSettingsWindow : Window
 {
     private readonly PluginManager _manager;
     private readonly string[] _themes;
-    
+
     private readonly Dictionary<string, ComboBox> _componentComboBoxes = new();
     private ComboBox? _globalThemeBox;
 
@@ -31,7 +31,7 @@ public partial class ThemeSettingsWindow : Window
     public ThemeSettingsWindow(PluginManager manager)
     {
         _manager = manager;
-        
+
         var themeDir = Path.Combine(AppContext.BaseDirectory, "Themes", "Global");
         _themes = Directory.Exists(themeDir)
             ? Directory.GetFiles(themeDir, "*.axaml")
@@ -59,13 +59,13 @@ public partial class ThemeSettingsWindow : Window
         panel.Children.Clear();
 
         // --- Global Theme Setting ---
-        panel.Children.Add(new TextBlock { Text = "Global Application Theme", FontWeight = FontWeight.Bold, Margin = new Thickness(0,0,0,4) });
+        panel.Children.Add(new TextBlock { Text = "Global Application Theme", FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 4) });
         _globalThemeBox = new ComboBox { ItemsSource = _themes, SelectedItem = SettingsManager.Settings.GlobalTheme };
         panel.Children.Add(_globalThemeBox);
-        panel.Children.Add(new Separator{ Margin = new Thickness(0, 10)});
+        panel.Children.Add(new Separator { Margin = new Thickness(0, 10) });
 
         // --- Per-Component Theme Settings ---
-        panel.Children.Add(new TextBlock { Text = "Component-Specific Themes (Overrides Global)", FontWeight = FontWeight.Bold, Margin = new Thickness(0,0,0,4) });
+        panel.Children.Add(new TextBlock { Text = "Component-Specific Themes (Overrides Global)", FontWeight = FontWeight.Bold, Margin = new Thickness(0, 0, 0, 4) });
         var components = new List<string> { "MainWindow" };
         components.AddRange(_manager.Plugins.Select(p => p.Name));
 
@@ -73,11 +73,11 @@ public partial class ThemeSettingsWindow : Window
         {
             var row = new Grid { ColumnDefinitions = new ColumnDefinitions("*,*") };
             row.Children.Add(new TextBlock { Text = comp, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center });
-            
+
             var box = new ComboBox { ItemsSource = _themes.Prepend("(Global Theme)").ToList() };
             Grid.SetColumn(box, 1);
             row.Children.Add(box);
-            
+
             if (SettingsManager.Settings.ComponentThemes.TryGetValue(comp, out var themeName))
             {
                 box.SelectedItem = themeName;
@@ -109,12 +109,12 @@ public partial class ThemeSettingsWindow : Window
                 map[comp] = themeName;
             }
         }
-        
+
         SettingsManager.Save();
-        
+
         var msg = new MessageWindow("Settings Saved", "Theme settings have been saved. Some changes may require an application restart to fully apply.");
         msg.ShowDialog(this);
-        
+
         Close();
     }
 

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -28,8 +28,8 @@ namespace Cycloside.ViewModels
             OnPropertyChanged(nameof(NextButtonText));
             OnPropertyChanged(nameof(ProgressText));
         }
-        
-        private const int TotalSteps = 3; 
+
+        private const int TotalSteps = 3;
 
         public string ProgressText => $"Step {CurrentStep + 1} of {TotalSteps}";
         public bool CanGoBack => CurrentStep > 0;
@@ -43,7 +43,7 @@ namespace Cycloside.ViewModels
 
         public ObservableCollection<string> AvailableThemes { get; } = new();
         public ObservableCollection<PluginItem> Plugins { get; } = new();
-        
+
         public event EventHandler? RequestClose;
 
         public WizardViewModel()
@@ -55,7 +55,7 @@ namespace Cycloside.ViewModels
                 SelectedTheme = AvailableThemes.Contains("MintGreen") ? "MintGreen" : AvailableThemes[0];
             }
         }
-        
+
         [RelayCommand]
         private void Back()
         {
@@ -73,27 +73,27 @@ namespace Cycloside.ViewModels
                 CurrentStep++;
                 return;
             }
-            
+
             SettingsManager.Settings.GlobalTheme = SelectedTheme;
             foreach (var item in Plugins)
             {
                 SettingsManager.Settings.PluginEnabled[item.Name] = item.IsEnabled;
             }
-            
+
             var profile = new WorkspaceProfile
             {
                 Name = ProfileName,
                 Plugins = Plugins.ToDictionary(p => p.Name, p => p.IsEnabled)
             };
             WorkspaceProfiles.AddOrUpdate(profile);
-            
+
             SettingsManager.Settings.ActiveProfile = ProfileName;
             SettingsManager.Settings.FirstRun = false;
             SettingsManager.Save();
-            
+
             RequestClose?.Invoke(this, EventArgs.Empty);
         }
-        
+
         private void LoadThemes()
         {
             try
@@ -105,7 +105,7 @@ namespace Cycloside.ViewModels
                     Logger.Log($"Wizard Error: Theme directory not found at '{dir}'");
                     return;
                 }
-                
+
                 foreach (var file in Directory.GetFiles(dir, "*.axaml"))
                 {
                     AvailableThemes.Add(Path.GetFileNameWithoutExtension(file));

--- a/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
+++ b/Cycloside/Widgets/BuiltIn/Mp3Widget.cs
@@ -62,7 +62,7 @@ namespace Cycloside.Widgets.BuiltIn
                     _plugin.SeekCommand.Execute(TimeSpan.FromSeconds(progressSlider.Value));
                 }
             }, RoutingStrategies.Tunnel);
-            
+
             // TextBlocks to display "01:23 / 04:56" style time.
             // We use StringFormat in the binding to format the TimeSpan without needing a converter.
             var currentTimeText = new TextBlock { Foreground = Brushes.LightGray, VerticalAlignment = VerticalAlignment.Center };
@@ -111,11 +111,11 @@ namespace Cycloside.Widgets.BuiltIn
                 Margin = new Thickness(0, 8, 0, 0)
             };
             buttonPanel.Children.AddRange(new Control[] { openButton, prevButton, playButton, pauseButton, stopButton, nextButton });
-            
+
             Grid.SetRow(buttonPanel, 2);
             Grid.SetColumn(buttonPanel, 0);
             Grid.SetColumnSpan(buttonPanel, 3);
-            
+
             mainPanel.Children.AddRange(new Control[] { trackDisplay, currentTimeText, progressSlider, totalTimeText, buttonPanel });
 
             return new Border

--- a/Cycloside/WorkspaceProfiles.cs
+++ b/Cycloside/WorkspaceProfiles.cs
@@ -10,7 +10,7 @@ namespace Cycloside;
 public class WorkspaceProfile
 {
     public string Name { get; set; } = string.Empty;
-    public Dictionary<string,bool> Plugins { get; set; } = new();
+    public Dictionary<string, bool> Plugins { get; set; } = new();
     public string Wallpaper { get; set; } = string.Empty;
     public string Theme { get; set; } = string.Empty;
 }
@@ -18,24 +18,24 @@ public class WorkspaceProfile
 public static class WorkspaceProfiles
 {
     private static readonly string ProfilePath = Path.Combine(AppContext.BaseDirectory, "profiles.json");
-    private static Dictionary<string,WorkspaceProfile> _profiles = Load();
+    private static Dictionary<string, WorkspaceProfile> _profiles = Load();
 
-    public static IReadOnlyDictionary<string,WorkspaceProfile> Profiles => _profiles;
+    public static IReadOnlyDictionary<string, WorkspaceProfile> Profiles => _profiles;
 
     public static IEnumerable<string> ProfileNames => _profiles.Keys;
 
-    private static Dictionary<string,WorkspaceProfile> Load()
+    private static Dictionary<string, WorkspaceProfile> Load()
     {
         try
         {
-            if(File.Exists(ProfilePath))
+            if (File.Exists(ProfilePath))
             {
                 var json = File.ReadAllText(ProfilePath);
-                var p = JsonSerializer.Deserialize<Dictionary<string,WorkspaceProfile>>(json);
-                if(p != null) return p;
+                var p = JsonSerializer.Deserialize<Dictionary<string, WorkspaceProfile>>(json);
+                if (p != null) return p;
             }
         }
-        catch {}
+        catch { }
         return new();
     }
 
@@ -43,30 +43,30 @@ public static class WorkspaceProfiles
     {
         try
         {
-            var json = JsonSerializer.Serialize(_profiles, new JsonSerializerOptions{WriteIndented=true});
+            var json = JsonSerializer.Serialize(_profiles, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(ProfilePath, json);
         }
-        catch {}
+        catch { }
     }
 
     public static void Apply(string name, PluginManager manager)
     {
-        if(!_profiles.TryGetValue(name, out var profile))
+        if (!_profiles.TryGetValue(name, out var profile))
             return;
 
-        foreach(var plugin in manager.Plugins)
+        foreach (var plugin in manager.Plugins)
         {
             var enable = profile.Plugins.TryGetValue(plugin.Name, out var e) && e;
-            if(enable && !manager.IsEnabled(plugin))
+            if (enable && !manager.IsEnabled(plugin))
                 manager.EnablePlugin(plugin);
-            else if(!enable && manager.IsEnabled(plugin))
+            else if (!enable && manager.IsEnabled(plugin))
                 manager.DisablePlugin(plugin);
         }
 
-        if(!string.IsNullOrWhiteSpace(profile.Wallpaper))
+        if (!string.IsNullOrWhiteSpace(profile.Wallpaper))
             WallpaperHelper.SetWallpaper(profile.Wallpaper);
 
-        if(!string.IsNullOrWhiteSpace(profile.Theme))
+        if (!string.IsNullOrWhiteSpace(profile.Theme))
             ThemeManager.LoadGlobalTheme(profile.Theme);
 
         SettingsManager.Settings.ActiveProfile = name;
@@ -81,13 +81,13 @@ public static class WorkspaceProfiles
 
     public static void Remove(string name)
     {
-        if(_profiles.Remove(name))
+        if (_profiles.Remove(name))
             Save();
     }
 
     public static void UpdatePlugin(string profileName, string pluginName, bool enabled)
     {
-        if(!_profiles.TryGetValue(profileName, out var profile))
+        if (!_profiles.TryGetValue(profileName, out var profile))
             return;
 
         profile.Plugins[pluginName] = enabled;


### PR DESCRIPTION
## Summary
- run dotnet format across Cycloside to resolve linter complaints
- normalize spacing in PluginBus and various built-in plugins

## Testing
- `dotnet build Cycloside/Cycloside.csproj` *(fails: namespace `Cycloside.Plugins.BuiltIn` already contains a definition for `JezzballSound`)*

------
https://chatgpt.com/codex/tasks/task_e_68942afc4cb08332a2017c67ae924864