### PR TITLE
Enable Winamp visualizer and restore Jezzball mouse walls

### DIFF
--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -565,7 +565,10 @@ Tips:
             };
             _timer.Tick += GameTick;
 
-            var canvas = new Canvas();
+            var canvas = new Canvas
+            {
+                Background = Brushes.Transparent // Make canvas hit-testable for pointer events
+            };
             canvas.PointerMoved += OnPointerMoved;
             canvas.PointerPressed += OnPointerPressed;
 

--- a/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
@@ -21,12 +21,11 @@ public class WinampVisHostPlugin : IPlugin
 
     public void Start()
     {
-        // Don't auto-start - wait for MP3layer to enable it
-        Logger.Log("Winamp Visual Host started - waiting for MP3able visualization");
-
-        // FIXED: Create the host window but don't show it yet
+        // Create the host window and immediately enable visualization so the
+        // Winamp plug-ins become visible without extra setup.
         _hostWindow = new VisHostWindow();
         ThemeManager.ApplyForPlugin(_hostWindow, this);
+        EnableVisualization();
     }
 
     public void Stop()


### PR DESCRIPTION
## Summary
- Automatically enable Winamp visualization host so plugins open in their own window
- Make Jezzball's canvas hit-testable to allow mouse-driven wall creation

## Testing
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6898d6ecd9bc83328bb16b96ea279a2e