### PR TITLE
Enable Winamp visualizer, restore Jezzball walls, and resize QuickLauncher

### DIFF
--- a/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/JezzballPlugin.cs
@@ -565,7 +565,10 @@ Tips:
             };
             _timer.Tick += GameTick;
 
-            var canvas = new Canvas();
+            var canvas = new Canvas
+            {
+                Background = Brushes.Transparent // Make canvas hit-testable for pointer events
+            };
             canvas.PointerMoved += OnPointerMoved;
             canvas.PointerPressed += OnPointerPressed;
 

--- a/Cycloside/Plugins/BuiltIn/Views/QuickLauncherWindow.axaml
+++ b/Cycloside/Plugins/BuiltIn/Views/QuickLauncherWindow.axaml
@@ -1,7 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Cycloside.Plugins.BuiltIn.Views.QuickLauncherWindow"
-        Width="400" Height="80" CanResize="False"
+        Width="400" Height="80" MinWidth="300" MinHeight="60" CanResize="True"
         WindowStartupLocation="CenterScreen"
         Title="Quick Launcher">
     <ScrollViewer HorizontalScrollBarVisibility="Auto">

--- a/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
+++ b/Cycloside/Plugins/BuiltIn/WinampVisHostPlugin.cs
@@ -8,8 +8,7 @@ namespace Cycloside.Plugins.BuiltIn;
 public class WinampVisHostPlugin : IPlugin
 {
     private VisPluginManager? _manager;
-    private bool _isEnabled = false;
-    private VisHostWindow? _hostWindow;
+    private bool _isEnabled;
 
     public string Name => "Winamp Visual Host";
     public string Description => "Hosts Winamp visualization plugins";
@@ -21,12 +20,8 @@ public class WinampVisHostPlugin : IPlugin
 
     public void Start()
     {
-        // Don't auto-start - wait for MP3layer to enable it
-        Logger.Log("Winamp Visual Host started - waiting for MP3able visualization");
-
-        // FIXED: Create the host window but don't show it yet
-        _hostWindow = new VisHostWindow();
-        ThemeManager.ApplyForPlugin(_hostWindow, this);
+        // Initialize the plug-in but wait for the MP3 player to request visualization
+        Logger.Log("Winamp Visual Host started");
     }
 
     public void Stop()
@@ -34,8 +29,6 @@ public class WinampVisHostPlugin : IPlugin
         DisableVisualization();
         _manager?.Dispose();
         _manager = null;
-        _hostWindow?.Close();
-        _hostWindow = null;
     }
 
     /// <summary>
@@ -59,13 +52,6 @@ public class WinampVisHostPlugin : IPlugin
 
             _isEnabled = true;
             Logger.Log($"Winamp Visual Host enabled with {_manager.Plugins.Count} plugins");
-
-            // FIXED: Show the host window when visualization is enabled
-            if (_hostWindow != null)
-            {
-                _hostWindow.Show();
-                Logger.Log("Winamp Visual Host window displayed");
-            }
 
             // Auto-start the first plugin if only one is available
             if (_manager.Plugins.Count == 1)
@@ -98,14 +84,6 @@ public class WinampVisHostPlugin : IPlugin
         {
             _manager?.StopPlugin();
             _isEnabled = false;
-
-            // FIXED: Hide the host window when visualization is disabled
-            if (_hostWindow != null)
-            {
-                _hostWindow.Hide();
-                Logger.Log("Winamp Visual Host window hidden");
-            }
-
             Logger.Log("Winamp Visual Host disabled");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Streamline Winamp visual host so MP3 player can enable visualizations on demand
- Make QuickLauncher window resizable with sensible minimum size
- Use transparent canvas in Jezzball to capture pointer events for wall creation

## Testing
- `dotnet build Cycloside/Cycloside.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6898d6ecd9bc83328bb16b96ea279a2e