### PR TITLE
Centralize built-in plugin metadata for startup and wizard

### DIFF
--- a/Cycloside/Plugins/BuiltInPluginCatalog.cs
+++ b/Cycloside/Plugins/BuiltInPluginCatalog.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Cycloside.Plugins.BuiltIn;
+
+namespace Cycloside.Plugins;
+
+/// <summary>
+/// Central registry for every built-in plugin so startup, wizards, and menus stay in sync.
+/// </summary>
+public static class BuiltInPluginCatalog
+{
+    /// <summary>
+    /// Metadata describing how to create a built-in plugin and whether it should be enabled by default.
+    /// </summary>
+    public sealed record BuiltInPluginDescriptor(
+        string Name,
+        Func<PluginManager, IPlugin> Factory,
+        bool EnabledByDefault = true,
+        bool IsSafe = false);
+
+    private static readonly IReadOnlyList<BuiltInPluginDescriptor> _descriptors = new List<BuiltInPluginDescriptor>
+    {
+        new("Date/Time Overlay", _ => new DateTimeOverlayPlugin()),
+        new("MP3 Player", _ => new MP3PlayerPlugin()),
+        new("Managed Visual Host", _ => new ManagedVisHostPlugin()),
+        new("Macro Engine", _ => new MacroPlugin()),
+        new("Text Editor", _ => new TextEditorPlugin()),
+        new("File Explorer", _ => new FileExplorerPlugin()),
+        new("Wallpaper Changer", _ => new WallpaperPlugin()),
+        new("Clipboard Manager", _ => new ClipboardManagerPlugin()),
+        new("Code Editor", _ => new CodeEditorPlugin()),
+        new("Character Map", _ => new CharacterMapPlugin()),
+        new("File Watcher", _ => new FileWatcherPlugin()),
+        new("Process Monitor", _ => new ProcessMonitorPlugin()),
+        new("Network Tools", _ => new NetworkToolsPlugin()),
+        new("Task Scheduler", _ => new TaskSchedulerPlugin()),
+        new("Disk Usage", _ => new DiskUsagePlugin()),
+        new("Encryption", _ => new EncryptionPlugin()),
+        new("Terminal", _ => new TerminalPlugin()),
+        new("Log Viewer", _ => new LogViewerPlugin()),
+        new("Notification Center", _ => new NotificationCenterPlugin()),
+        new("Environment Editor", _ => new EnvironmentEditorPlugin()),
+        new("ModPlug Tracker", _ => new ModTrackerPlugin(), EnabledByDefault: false),
+        new("Jezzball", _ => new JezzballPlugin()),
+        new("Quick Launcher", manager => new QuickLauncherPlugin(manager)),
+        new("Widget Host", manager => new WidgetHostPlugin(manager)),
+        new("QBasic Retro IDE", _ => new QBasicRetroIDEPlugin(), EnabledByDefault: false)
+    };
+
+    public static IReadOnlyList<BuiltInPluginDescriptor> Descriptors => _descriptors;
+}

--- a/Cycloside/ViewModels/WizardViewModel.cs
+++ b/Cycloside/ViewModels/WizardViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Cycloside; // core models and services
+using Cycloside.Plugins;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -119,17 +120,13 @@ namespace Cycloside.ViewModels
 
         private void LoadPlugins()
         {
-            string[] names =
+            foreach (var descriptor in BuiltInPluginCatalog.Descriptors)
             {
-                "Date/Time Overlay", "MP3 Player", "Macro Engine", "Text Editor", "File Explorer", "Wallpaper Changer",
-                "Clipboard Manager", "File Watcher", "Process Monitor", "Task Scheduler",
-                "Disk Usage", "Log Viewer", "Environment Editor", "Jezzball",
-                "Widget Host", "Winamp Vis Host", "QBasic Retro IDE", "ScreenSaver Host"
-            };
-
-            foreach (var n in names)
-            {
-                Plugins.Add(new PluginItem { Name = n, IsEnabled = true });
+                Plugins.Add(new PluginItem
+                {
+                    Name = descriptor.Name,
+                    IsEnabled = descriptor.EnabledByDefault
+                });
             }
         }
     }


### PR DESCRIPTION
## Summary
- centralize built-in plugin registration in a shared catalog and load defaults with proper persistence updates
- register additional built-in plugins that were previously omitted and ensure default enablement flags are honored
- drive the first-run wizard from the shared catalog so the presented options stay aligned with actual built-ins

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d621ae5ef08332b3d6f7b1a8a09d5e